### PR TITLE
Add markdown table rendering and DND_CAMPAIGN_ROOT support (#8, #9)

### DIFF
--- a/display/app.py
+++ b/display/app.py
@@ -47,6 +47,8 @@ except Exception:
     _lookup = None          # type: ignore
     _SRD_AVAILABLE = False
 
+from paths import find_campaign as _find_campaign
+
 # Audio module — degrades silently if numpy not installed
 _AUDIO_DIR = os.path.dirname(os.path.abspath(__file__))
 import sys as _sys
@@ -441,7 +443,7 @@ SCENES: dict[str, dict] = {
         "keywords": [
             "city", "market", "street", "crowd", "village", "town",
             "square", "cobble", "district", "quarter", "merchant",
-            "citadel",
+            "ashenveil",
         ],
         "colors": ["#0a0f1a", "#15202e"],
         "accent": "#6080a0",
@@ -733,7 +735,7 @@ def _get_tail_file() -> str:
     try:
         camp = open(CAMP_FILE).read().strip()
         if camp:
-            return os.path.expanduser(f"~/.claude/dnd/campaigns/{camp}/session_tail.json")
+            return str(_find_campaign(camp) / "session_tail.json")
     except Exception:
         pass
     return _TAIL_FALLBACK
@@ -1397,7 +1399,7 @@ def help_request():
 def player_input():
     """Queue a player action submitted from the display companion.
 
-    Body: {"character": "Torven", "text": "I draw my sword", "hold": false}
+    Body: {"character": "Mira", "text": "I draw my rapier", "hold": false}
     Broadcasts pending_input event to all connected browsers.
     """
     if not _token_ok():
@@ -1461,7 +1463,7 @@ def device_deny():
 def stage_input():
     """Stage a player action for review. Broadcasts staged_inputs to all displays.
 
-    Body: {"character": "Torven", "text": "draws their blade"}
+    Body: {"character": "Mira", "text": "draws her rapier"}
     """
     if not _token_ok():
         return "Forbidden", 403
@@ -1510,7 +1512,7 @@ def stage_input():
 def ready_input():
     """Toggle the ready flag for a staged character.
 
-    Body: {"character": "Torven", "ready": true}
+    Body: {"character": "Mira", "ready": true}
     Triggers auto-fire when all expected players are ready.
     """
     if not _token_ok():
@@ -1547,7 +1549,7 @@ def ready_input():
 def unstage_input():
     """Remove a character's staged action (e.g. player wants to edit it).
 
-    Body: {"character": "Torven"}
+    Body: {"character": "Mira"}
     """
     if not _token_ok():
         return "Forbidden", 403
@@ -1572,7 +1574,7 @@ def skip_input():
     """Skip a character's turn — stages a 'skips their turn' entry marked ready.
 
     Counts toward the auto-trigger threshold and fires auto-trigger if threshold met.
-    Body: {"character": "Torven"}
+    Body: {"character": "Mira"}
     """
     if not _token_ok():
         return "Forbidden", 403

--- a/display/dm_help.py
+++ b/display/dm_help.py
@@ -24,6 +24,8 @@ import pathlib
 import re
 import subprocess
 import sys
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent / "scripts"))
+from paths import find_campaign as _find_campaign
 
 BASE      = pathlib.Path("~/.claude/skills/dnd").expanduser()
 LOCK_FILE = BASE / "display" / ".help-lock"
@@ -82,9 +84,7 @@ def get_campaign_state(campaign: str) -> str:
     Skips Open Threads and Recent Events — those go stale mid-session.
     session-log.md is the authoritative source for in-session state.
     """
-    state_path = pathlib.Path(
-        f"~/.claude/dnd/campaigns/{campaign}/state.md"
-    ).expanduser()
+    state_path = _find_campaign(campaign) / "state.md"
     if not state_path.exists():
         return ""
     text = state_path.read_text()
@@ -108,9 +108,7 @@ def get_session_context(campaign: str) -> str:
     current session — more current than state.md during an active session.
     Falls back to the archive if the main log is empty or has no sessions.
     """
-    log_path = pathlib.Path(
-        f"~/.claude/dnd/campaigns/{campaign}/session-log.md"
-    ).expanduser()
+    log_path = _find_campaign(campaign) / "session-log.md"
     if not log_path.exists():
         return ""
     text = log_path.read_text()

--- a/display/templates/index.html
+++ b/display/templates/index.html
@@ -144,8 +144,40 @@
     text-shadow: 0 1px 6px rgba(0,0,0,0.8);
   }
 
-  /* Italic for atmospheric/narration lines */
-  .dm-block p em { color: #c8b080; }
+  /* Emphasis inside narration — warm amber, upright (italic is hard to read at distance) */
+  .dm-block p em {
+    color: #c8b080;
+    font-style: normal;
+  }
+
+  /* Markdown tables inside narration */
+  .dm-block table.dm-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0.8em 0 1em;
+    font-size: 0.92em;
+    color: #d4c4a0;
+    text-shadow: 0 1px 6px rgba(0,0,0,0.8);
+  }
+  .dm-block table.dm-table th {
+    text-align: left;
+    padding: 0.45em 0.9em;
+    background: rgba(80, 55, 30, 0.35);
+    color: rgba(230, 210, 170, 0.95);
+    font-weight: 600;
+    border-bottom: 1px solid rgba(180, 140, 90, 0.45);
+  }
+  .dm-block table.dm-table td {
+    padding: 0.4em 0.9em;
+    border-bottom: 1px solid rgba(180, 140, 90, 0.18);
+    vertical-align: top;
+  }
+  .dm-block table.dm-table tr:last-child td {
+    border-bottom: none;
+  }
+  .dm-block table.dm-table strong {
+    color: #ffffff;
+  }
 
   /* ── Player action blocks ── */
   .player-block {
@@ -226,10 +258,14 @@
   }
 
   .npc-block p {
-    color: #c8a878;
-    font-style: italic;
+    color: #ffffff;
+    font-style: normal;
     font-size: 0.95em;
     text-shadow: 0 1px 6px rgba(0,0,0,0.8);
+  }
+  .npc-block p em {
+    font-style: normal;
+    color: #ffffff;
   }
 
   /* ── Dice result blocks ── */
@@ -2154,14 +2190,12 @@ let idleTimer       = null;
 
 // ── Markdown segment parser ───────────────────────────────────────────────────
 // Converts a text string into typed queue items for the typewriter.
-// Items are either plain chars/'\n' strings, or {open:'em'}/{close:'em'} objects.
-function _mdParse(text) {
-  const items = [];
+// Items are plain chars, '\n' strings, {open/close tag} objects, or {table} objects.
+
+// Parse inline markdown (bold, italic) from a single line into items array.
+function _mdParseInline(text, items) {
   let i = 0;
   while (i < text.length) {
-    if (text[i] === '\n') {
-      items.push('\n'); i++; continue;
-    }
     // Bold (**text**) — must check before single *
     if (text[i] === '*' && text[i + 1] === '*') {
       const end = text.indexOf('**', i + 2);
@@ -2181,6 +2215,98 @@ function _mdParse(text) {
       i = end + 1; continue;
     }
     items.push(text[i]); i++;
+  }
+}
+
+// Split a markdown table row "| a | b | c |" into ["a","b","c"].
+function _splitTableRow(line) {
+  let s = line.trim();
+  if (s.startsWith('|')) s = s.slice(1);
+  if (s.endsWith('|'))   s = s.slice(0, -1);
+  return s.split('|').map(c => c.trim());
+}
+
+// Detect a markdown table block starting at lines[idx].
+// Returns {headers, rows, end} or null.
+function _detectTable(lines, idx) {
+  const header = lines[idx];
+  const sep    = lines[idx + 1];
+  if (!header || !sep) return null;
+  if (!/^\s*\|.*\|\s*$/.test(header)) return null;
+  if (!/^\s*\|?\s*:?-{2,}:?(\s*\|\s*:?-{2,}:?)+\s*\|?\s*$/.test(sep)) return null;
+  const headerCells = _splitTableRow(header);
+  const rows = [];
+  let j = idx + 2;
+  while (j < lines.length && /^\s*\|.*\|\s*$/.test(lines[j])) {
+    rows.push(_splitTableRow(lines[j]));
+    j++;
+  }
+  return { headers: headerCells, rows, end: j };
+}
+
+// Build a <table> DOM node from a parsed table segment.
+function _buildTableNode(tbl) {
+  const t = document.createElement('table');
+  t.className = 'dm-table';
+  if (tbl.headers && tbl.headers.length) {
+    const thead = document.createElement('thead');
+    const tr = document.createElement('tr');
+    tbl.headers.forEach(h => {
+      const th = document.createElement('th');
+      const inline = [];
+      _mdParseInline(h, inline);
+      _appendInlineSegments(th, inline);
+      tr.appendChild(th);
+    });
+    thead.appendChild(tr);
+    t.appendChild(thead);
+  }
+  const tbody = document.createElement('tbody');
+  tbl.rows.forEach(row => {
+    const tr = document.createElement('tr');
+    row.forEach(cell => {
+      const td = document.createElement('td');
+      const inline = [];
+      _mdParseInline(cell, inline);
+      _appendInlineSegments(td, inline);
+      tr.appendChild(td);
+    });
+    tbody.appendChild(tr);
+  });
+  t.appendChild(tbody);
+  return t;
+}
+
+// Append a flat list of inline segments to a DOM node.
+function _appendInlineSegments(parent, segments) {
+  let inline = null;
+  for (const s of segments) {
+    if (s && typeof s === 'object' && s.open) {
+      const el = document.createElement(s.open);
+      parent.appendChild(el);
+      inline = el;
+    } else if (s && typeof s === 'object' && s.close) {
+      inline = null;
+    } else {
+      (inline || parent).appendChild(document.createTextNode(s));
+    }
+  }
+}
+
+// Main parser: splits text into lines, detects table blocks, falls back to inline parsing.
+function _mdParse(text) {
+  const items = [];
+  const lines = text.split('\n');
+  for (let li = 0; li < lines.length; li++) {
+    const tbl = _detectTable(lines, li);
+    if (tbl) {
+      items.push({ table: { headers: tbl.headers, rows: tbl.rows } });
+      li = tbl.end - 1;
+      if (li < lines.length - 1) items.push('\n');
+      continue;
+    }
+    _mdParseInline(lines[li], items);
+    if (li < lines.length - 1) items.push('\n');
   }
   return items;
 }
@@ -2223,6 +2349,9 @@ function typeNextChar() {
     _currentInlineEl = null;
     const next = document.createElement('p');
     currentEl.appendChild(next);
+  } else if (item && typeof item === 'object' && item.table) {
+    _currentInlineEl = null;
+    currentEl.appendChild(_buildTableNode(item.table));
   } else if (item && typeof item === 'object' && item.open) {
     // Open a styled inline element inside current paragraph
     const el = document.createElement(item.open);
@@ -2282,6 +2411,10 @@ function instantFlush() {
       if (!currentEl) getOrCreateBlock();
       const next = document.createElement('p');
       currentEl.appendChild(next);
+    } else if (item && typeof item === 'object' && item.table) {
+      flushInline = null;
+      if (!currentEl) getOrCreateBlock();
+      currentEl.appendChild(_buildTableNode(item.table));
     } else if (item && typeof item === 'object' && item.open) {
       const p = getOrCreateBlock();
       const el = document.createElement(item.open);
@@ -2516,7 +2649,7 @@ function renderXpBlock(xpData) {
   block.className = 'xp-block';
   const line = document.createElement('div');
   line.className = 'xp-line';
-  // names line: "Aldric, Mira — +250 XP"
+  // names line: "Kat, Ben — +250 XP"
   const names = (xpData.names || []).join(', ');
   const amt   = xpData.xp != null ? `+${xpData.xp} XP` : '';
   line.textContent = [names, amt].filter(Boolean).join(' — ');
@@ -2565,7 +2698,7 @@ function renderReplayBatch(items) {
       block.style.opacity = '0.75';
       item.text.split('\n').forEach(line => {
         const p = document.createElement('p');
-        p.textContent = line;
+        _appendInlineSegments(p, _mdParse(line));
         block.appendChild(p);
       });
       textContent.appendChild(block);
@@ -2672,7 +2805,7 @@ function renderReplay(text) {
   block.style.opacity = '0.75';   // subtle visual distinction for historical text
   cleaned.split('\n').forEach(line => {
     const p = document.createElement('p');
-    p.textContent = line;
+    _appendInlineSegments(p, _mdParse(line));
     block.appendChild(p);
   });
   textContent.appendChild(block);

--- a/scripts/build_supplemental.py
+++ b/scripts/build_supplemental.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 """
 build_supplemental.py — fetch and cache non-SRD spell/feature descriptions
 
@@ -8,10 +9,10 @@ dnd5e_supplemental.json so the display companion can resolve them locally.
 
 Usage:
     # Scan a campaign's characters and fetch anything missing
-    python3 build_supplemental.py --campaign mom-dad-campaign-0
+    python3 build_supplemental.py --campaign my-campaign
 
     # Scan a specific character file
-    python3 build_supplemental.py --character ~/.claude/dnd/campaigns/X/characters/ben.md
+    python3 build_supplemental.py --character ~/.claude/dnd/campaigns/my-campaign/characters/aldric.md
 
     # Add specific entries by name + category
     python3 build_supplemental.py --add "Toll the Dead" spell
@@ -35,7 +36,9 @@ import urllib.parse
 from html.parser import HTMLParser
 
 SKILLS_DIR       = os.path.expanduser("~/.claude/skills/dnd")
-CAMPAIGNS_DIR    = os.path.expanduser("~/.claude/dnd/campaigns")
+
+from paths import campaigns_dir as _campaigns_dir, find_campaign as _find_campaign
+CAMPAIGNS_DIR    = str(_campaigns_dir())
 DATA_FILE        = os.path.join(SKILLS_DIR, "data", "dnd5e_srd.json")
 SUPPLEMENTAL_FILE = os.path.join(SKILLS_DIR, "data", "dnd5e_supplemental.json")
 
@@ -320,7 +323,7 @@ def main() -> None:
 
     # Collect from --campaign
     if args.campaign:
-        camp_dir = os.path.join(CAMPAIGNS_DIR, args.campaign, "characters")
+        camp_dir = os.path.join(str(_find_campaign(args.campaign)), "characters")
         if not os.path.isdir(camp_dir):
             print(f"Campaign characters directory not found: {camp_dir}", file=sys.stderr)
             sys.exit(1)

--- a/scripts/calendar.py
+++ b/scripts/calendar.py
@@ -46,6 +46,7 @@ import os
 import sys
 import subprocess
 import argparse
+from paths import find_campaign as _find_campaign
 
 SEND_PY = os.path.expanduser("~/.claude/skills/dnd/display/send.py")
 
@@ -72,7 +73,7 @@ HOURS_PER_TIME = {
 
 
 def _cal_path(campaign: str) -> str:
-    d = os.path.expanduser(f"~/.claude/dnd/campaigns/{campaign}")
+    d = str(_find_campaign(campaign))
     os.makedirs(d, exist_ok=True)
     return os.path.join(d, "calendar.json")
 

--- a/scripts/campaign_search.py
+++ b/scripts/campaign_search.py
@@ -8,8 +8,8 @@ Usage:
     python3 campaign_search.py -c <campaign> <keyword> -C 4   # context lines (default 3)
 
 Examples:
-    python3 ~/.claude/skills/dnd/scripts/campaign_search.py -c mom-dad-campaign-0 Lasswater
-    python3 ~/.claude/skills/dnd/scripts/campaign_search.py -c mom-dad-campaign-0 Vael letter --files log,archive
+    python3 ~/.claude/skills/dnd/scripts/campaign_search.py -c my-campaign dragon
+    python3 ~/.claude/skills/dnd/scripts/campaign_search.py -c my-campaign Vael letter --files log,archive
     python3 ~/.claude/skills/dnd/scripts/campaign_search.py -c test-campaign VARETH Kel
 
 Returns: file name, nearest section heading, and matching lines with context.
@@ -21,7 +21,8 @@ import os
 import argparse
 import re
 
-CAMPAIGNS_DIR = os.path.expanduser("~/.claude/dnd/campaigns")
+from paths import campaigns_dir as _campaigns_dir
+CAMPAIGNS_DIR = str(_campaigns_dir())
 
 FILE_MAP = {
     "state":   "state.md",

--- a/scripts/paths.py
+++ b/scripts/paths.py
@@ -1,0 +1,82 @@
+"""
+paths.py — canonical path resolution for DND campaign and character data.
+
+All scripts that need to locate campaign or character files should import from
+here rather than hardcoding ~/.claude/dnd/. Set DND_CAMPAIGN_ROOT to move your
+data anywhere — iCloud, Dropbox, network share, etc. Defaults to ~/.claude/dnd.
+
+Usage:
+    from paths import campaigns_dir, characters_dir, campaign_dir, find_campaign
+
+Environment:
+    DND_CAMPAIGN_ROOT   Root of campaign data tree. Default: ~/.claude/dnd
+                        Example: export DND_CAMPAIGN_ROOT=~/iCloud/dnd
+"""
+
+import os
+import pathlib
+import shutil
+import sys
+
+_DEFAULT_ROOT = pathlib.Path("~/.claude/dnd").expanduser()
+
+
+def _root() -> pathlib.Path:
+    """Return the configured data root, expanded and absolute."""
+    raw = os.environ.get("DND_CAMPAIGN_ROOT", "")
+    if raw.strip():
+        return pathlib.Path(raw.strip()).expanduser().resolve()
+    return _DEFAULT_ROOT
+
+
+def campaigns_dir() -> pathlib.Path:
+    """Return the campaigns directory under the configured root."""
+    return _root() / "campaigns"
+
+
+def characters_dir() -> pathlib.Path:
+    """Return the global characters directory under the configured root."""
+    return _root() / "characters"
+
+
+def campaign_dir(name: str) -> pathlib.Path:
+    """Return the directory for a specific campaign under the configured root."""
+    return campaigns_dir() / name
+
+
+def find_campaign(name: str) -> pathlib.Path:
+    """Locate a campaign directory, with legacy fallback and optional migration.
+
+    Resolution order:
+    1. $DND_CAMPAIGN_ROOT/campaigns/<name>/  — configured root (or default)
+    2. ~/.claude/dnd/campaigns/<name>/       — legacy default (only checked when
+       DND_CAMPAIGN_ROOT is set to a *different* path)
+
+    When a campaign is found at the legacy path and the configured root is custom,
+    the campaign is copied to the configured root so subsequent sessions use the
+    new location. The original is left in place (no files are deleted).
+
+    Returns the path to the campaign directory (may not exist if not found anywhere).
+    """
+    configured = campaign_dir(name)
+    if configured.exists():
+        return configured
+
+    # Only check legacy fallback if a custom root is configured
+    custom_root = os.environ.get("DND_CAMPAIGN_ROOT", "").strip()
+    if not custom_root:
+        return configured  # no custom root — nothing to fall back to
+
+    legacy = _DEFAULT_ROOT / "campaigns" / name
+    if not legacy.exists():
+        return configured  # not found in legacy location either
+
+    # Found at legacy path — copy to configured root
+    configured.parent.mkdir(parents=True, exist_ok=True)
+    print(
+        f"[paths] Campaign '{name}' found at legacy path {legacy}\n"
+        f"[paths] Copying to {configured} (original kept in place)",
+        file=sys.stderr,
+    )
+    shutil.copytree(str(legacy), str(configured))
+    return configured

--- a/scripts/tracker.py
+++ b/scripts/tracker.py
@@ -44,6 +44,7 @@ import subprocess
 import argparse
 import time
 from datetime import datetime, timezone
+from paths import find_campaign as _find_campaign
 
 PUSH_STATS = os.path.expanduser("~/.claude/skills/dnd/display/push_stats.py")
 SEND_PY    = os.path.expanduser("~/.claude/skills/dnd/display/send.py")
@@ -69,7 +70,7 @@ CONDITION_COLOURS = {
 
 
 def _state_path(campaign: str) -> str:
-    d = os.path.expanduser(f"~/.claude/dnd/campaigns/{campaign}")
+    d = str(_find_campaign(campaign))
     os.makedirs(d, exist_ok=True)
     return os.path.join(d, "tracker.json")
 

--- a/scripts/xp.py
+++ b/scripts/xp.py
@@ -93,7 +93,8 @@ LEVEL_XP: dict[int, int] = {
 DIFF_IDX: dict[str, int] = {"easy": 0, "medium": 1, "hard": 2, "deadly": 3}
 DIFF_LABELS: dict[int, str] = {0: "Easy", 1: "Medium", 2: "Hard", 3: "Deadly"}
 
-CAMPAIGNS_DIR = pathlib.Path("~/.claude/dnd/campaigns").expanduser()
+from paths import find_campaign as _find_campaign, campaigns_dir as _campaigns_dir
+CAMPAIGNS_DIR = _campaigns_dir()
 DISPLAY_SCRIPT = pathlib.Path("~/.claude/skills/dnd/display/push_stats.py").expanduser()
 
 


### PR DESCRIPTION
## Summary

- **Issue #8** — markdown tables now render in the display companion typewriter stream, with warm-stone palette styling consistent with existing dm/npc blocks; inline markdown (bold/italic) applied to replay paths; removed italic styling from em elements in dm/npc blocks for TV-distance readability
- **Issue #9** — new `scripts/paths.py` centralizes all campaign path resolution behind `DND_CAMPAIGN_ROOT` env var (defaults to `~/.claude/dnd`, fully backwards-compatible); `find_campaign()` provides legacy fallback with copy-not-move migration; all 8 call sites updated

## Call sites updated (issue #9)
`campaign_search.py`, `xp.py`, `calendar.py`, `tracker.py`, `build_supplemental.py`, `display/dm_help.py`, `display/app.py`

Closes #8, closes #9