### PR TITLE
fix: send.py stdin hang + feat: --inspiration-reason renders inside block

### DIFF
--- a/SKILL-commands.md
+++ b/SKILL-commands.md
@@ -66,6 +66,8 @@ Full step-by-step procedures for all `/dnd` slash commands. Load this file at `/
      - none of the above (plain DM narration) → `send.py` with text via stdin
      This restores the last scene to the display before the recap. The tail is written continuously by `dnd-display-app.py` — it always contains the last session's final exchanges regardless of how the session ended.
    - Clear previous transcript: `python3 ~/.claude/skills/dnd/display/push_stats.py --clear`
+
+     ⚠ **`--clear` wipes both text log AND stats** (player card, world time, factions, quests). It must always be paired with the full `--replace-players ... --world-time ... --factions ... --quests ...` push from step 4 — otherwise the sidebar card and sheet tab render empty. Same rule applies any time you `--clear` mid-session (e.g. restoring scene state after a re-replay): always re-push the full character JSON + world-time + factions + quests in the same bash burst as the clear.
    - Register active campaign for DM Help: `python3 ~/.claude/skills/dnd/display/push_stats.py --set-campaign <campaign-name>`
    - If autorun **yes** → write `autorun: true` to `state.md → ## Session Flags`; enter the autorun wait after the recap paragraph.
    - If autorun **no** → continue without autorun; DM drives turns manually.

--- a/display/dnd-display-app.py
+++ b/display/dnd-display-app.py
@@ -994,8 +994,12 @@ def chunk():
         name = str(data.get("inspiration_award", "")).strip()[:80]
         if not name:
             return "", 204
+        reason = str(data.get("reason", "")).strip()[:240]
         payload: dict = {"inspiration_award": name, "text": name}
         log_entry: dict = {"inspiration_award": name, "text": name}
+        if reason:
+            payload["reason"] = reason
+            log_entry["reason"] = reason
         with _text_log_lock:
             _text_log.append(log_entry)
         with _tail_lock:

--- a/display/send.py
+++ b/display/send.py
@@ -307,6 +307,9 @@ def main() -> None:
     # ── Inspiration / XP award flags ─────────────────────────────────────────
     parser.add_argument("--inspiration-award", metavar="NAME",
         help="Award Inspiration: fires a styled gold block in the feed + sidebar badge")
+    parser.add_argument("--inspiration-reason", metavar="TEXT",
+        help="Optional reason to render below the name in the inspiration block "
+             "(matches how --xp-award reason is rendered). Requires --inspiration-award.")
     parser.add_argument("--inspiration-spend", metavar="NAME",
         help="Spend/clear Inspiration: removes sidebar badge")
     parser.add_argument("--xp-award", metavar="JSON",
@@ -355,7 +358,10 @@ def main() -> None:
     # ── Inspiration award/spend (bypass normal text flow) ─────────────────────
     if args.inspiration_award:
         name = args.inspiration_award.strip()
-        _post(FLASK_URL, json.dumps({"inspiration_award": name, "text": name}).encode(), token)
+        body: dict = {"inspiration_award": name, "text": name}
+        if args.inspiration_reason:
+            body["reason"] = args.inspiration_reason.strip()
+        _post(FLASK_URL, json.dumps(body).encode(), token)
         _post(STATS_URL, json.dumps({"players": [{"name": name, "inspiration": True}]}).encode(), token)
         return
 

--- a/display/send.py
+++ b/display/send.py
@@ -338,7 +338,18 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    text = sys.stdin.read()
+    # Only read stdin when a content flag (or no flag at all = plain narration)
+    # is set. Body-less flags (inspiration / xp-award / stat-only) have no text
+    # body and must not touch stdin — when chained in a multi-command Bash
+    # block, the parent shell's stdin pipe stays open until the whole bash
+    # exits, so a body-less stdin.read() would block for the entire bash
+    # duration and silently drop every subsequent send in the chain.
+    _has_content_flag = bool(args.player or args.npc or args.dice or args.tutor or args.action)
+    _has_bodyless_flag = bool(
+        args.inspiration_award or args.inspiration_spend or args.xp_award
+        or _build_stats_payload(args)
+    )
+    text = sys.stdin.read() if (_has_content_flag or not _has_bodyless_flag) else ""
     token = _read_token()
 
     # ── Inspiration award/spend (bypass normal text flow) ─────────────────────

--- a/display/templates/index.html
+++ b/display/templates/index.html
@@ -958,6 +958,11 @@
     font-size: 12px; font-style: italic;
     color: rgba(220,190,60,0.55); margin-top: 3px;
   }
+  .inspiration-detail {
+    font-size: 11px; font-style: italic;
+    color: rgba(220,190,60,0.42); margin-top: 6px;
+    line-height: 1.4;
+  }
 
   /* ── XP award feed block ── */
   .xp-block {
@@ -2801,7 +2806,7 @@ function renderTutorBlock(text, isReplay) {
 }
 
 // ── Inspiration award block ────────────────────────────────────────────────
-function renderInspirationBlock(name) {
+function renderInspirationBlock(name, reason) {
   _flushForBlock();
   const block = document.createElement('div');
   block.className = 'inspiration-block';
@@ -2815,6 +2820,12 @@ function renderInspirationBlock(name) {
   sub.textContent = 'Inspiration';
   block.appendChild(title);
   block.appendChild(sub);
+  if (reason) {
+    const detail = document.createElement('div');
+    detail.className = 'inspiration-detail';
+    detail.textContent = reason;
+    block.appendChild(detail);
+  }
   textContent.appendChild(block);
   _reanchorCursor();
   scrollToBottom();
@@ -2852,7 +2863,7 @@ function renderReplayBatch(items) {
   items.forEach(item => {
     if (!item) return;
     if (item.inspiration_award) {
-      renderInspirationBlock(item.inspiration_award);
+      renderInspirationBlock(item.inspiration_award, item.reason || '');
       return;
     }
     if (item.xp_award) {
@@ -4555,7 +4566,7 @@ function connect() {
       _playSfx(payload.sfx);
     }
     if (payload.inspiration_award) {
-      renderInspirationBlock(payload.inspiration_award);
+      renderInspirationBlock(payload.inspiration_award, payload.reason || '');
     }
     if (payload.xp_award) {
       renderXpBlock(payload.xp_award);


### PR DESCRIPTION
## Summary
- **fix (commit 1)**: `send.py` — skip `stdin.read()` for body-less flag invocations so chained Bash bursts no longer drop subsequent sends
- **feat (commit 2)**: new `--inspiration-reason TEXT` flag plus 3-layer plumbing so the *why* of an inspiration award renders inside the gold block (mirrors how `--xp-award` reason already works)

## Why — fix commit
The unconditional `text = sys.stdin.read()` at the top of `main()` blocks whenever the parent stdin pipe stays open with no EOF. In a multi-command Bash block, the heredoc on the first command is local to that command — every chained command after it inherits the harness's open stdin pipe, which doesn't EOF until the whole bash exits. Result: a body-less call (e.g. `--inspiration-award NAME` with no heredoc) hangs for the full bash duration, and every send queued after it in the chain is silently dropped.

Repro:
```bash
send.py --player NAME << END ... END    # ✓ delivered
send.py --inspiration-award NAME         # ✗ HANGS for entire bash
send.py --npc NAME << END ... END        # ✗ never runs
send.py << END ... END                   # ✗ never runs
```

Fix: read stdin only when a content flag is set (`--player`, `--npc`, `--dice`, `--tutor`, `--action`) or when no flag is set at all (plain narration mode). Body-less invocations (`--inspiration-*`, `--xp-award`, `--stat-*`, `--effect-*`) get `text=""` without ever calling `sys.stdin.read()`.

## Why — feat commit
Standard 12 ("name *why* when awarding inspiration") was invisible to the player. The inspiration block only carried the name; any reason text the DM wrote in their narration response had no plumbed path to the display. `--xp-award` already supports `reason` end-to-end, so this commit mirrors that pattern for inspiration:

- `send.py`: new `--inspiration-reason TEXT` flag (requires `--inspiration-award`)
- `dnd-display-app.py`: accepts optional `reason` (240-char cap), persists to log + tail, broadcasts in payload
- `templates/index.html`: new `.inspiration-detail` CSS (italic, gold-tinted), `renderInspirationBlock(name, reason)` appends a detail div when reason is provided, both call sites updated

All changes are backward compatible — existing callers passing only `--inspiration-award NAME` continue to work unchanged.

## Test plan
- [x] **fix**: 4-block chained burst (player + inspiration-award + npc + narration) delivers all 4 in ~0.12s. Pre-fix the same chain delivered only the first.
- [x] **fix**: heredoc-fed `--player` / `--npc` still receives full text body
- [x] **fix**: plain narration (`send.py << END ... END` with no flag) still works
- [x] **feat**: `send.py --inspiration-award NAME --inspiration-reason "..."` writes a log entry with both `inspiration_award` and `reason`, and `/chunk` accepts + broadcasts the reason field
- [x] **feat**: backward compat — `send.py --inspiration-award NAME` (no reason) renders identical to before
- [ ] Reviewer to confirm in browser: reason text appears in italic gold inside the inspiration block, below the "Inspiration" sub-label