### PR TITLE
fix: send.py preserves bundled narration when paired with award flags

### DIFF
--- a/display/send.py
+++ b/display/send.py
@@ -436,31 +436,29 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    # Three categories of flags drive whether to read stdin:
+    # Two categories of flags drive whether to read stdin:
     #   1. Content flags (--player/--npc/--dice/--tutor/--action): body REQUIRED.
-    #   2. Truly body-less flags (inspiration/xp/milestone awards/spends):
-    #      body NEVER expected; reading stdin would block forever in a chained
-    #      bash block where the parent shell's stdin pipe is still open.
-    #   3. Stat flags (--stat-* / --effect-*): body OPTIONAL — they can be sent
-    #      alone OR bundled with narration. Read stdin only if it is actually
-    #      piped (heredoc / pipe), not if it is an interactive TTY.
+    #      Always read stdin — script will abort below if the body is empty.
+    #   2. Everything else (plain narration, stat-only, award-only, award+body):
+    #      body OPTIONAL. Read stdin when piped (heredoc/pipe), skip when an
+    #      interactive TTY to avoid blocking on an unattended call.
+    #
+    # Award flags (--inspiration-*/--xp-*/--milestone-*) used to force text=""
+    # which silently dropped any heredoc body bundled with them. Reading piped
+    # stdin under the same isatty() gate as stat flags lets bundled narration
+    # flow through to the text-send block below.
     _has_content_flag = bool(args.player or args.npc or args.dice or args.tutor or args.action)
-    _truly_bodyless = bool(
-        args.inspiration_award or args.inspiration_spend or args.xp_award
-        or args.milestone_award or args.milestone_spend
-    )
     if _has_content_flag:
         text = sys.stdin.read()
-    elif _truly_bodyless:
-        text = ""
     else:
-        # Plain narration (no flags) or stat-only.
-        # Read stdin when piped (heredoc); skip when interactive TTY to avoid
-        # blocking on an unattended stat-only call.
         text = "" if sys.stdin.isatty() else sys.stdin.read()
     token = _read_token()
 
-    # ── Inspiration award/spend (bypass normal text flow) ─────────────────────
+    # ── Inspiration award/spend ──────────────────────────────────────────────
+    # Award/spend flags POST their styled block + stat update first, then fall
+    # through to the text-send block below. Bundling a heredoc body with an
+    # award flag now broadcasts BOTH the gold block AND the narration chunk —
+    # previously the narration was silently dropped by an early return here.
     if args.inspiration_award:
         name = args.inspiration_award.strip()
         body: dict = {"inspiration_award": name, "text": name}
@@ -468,12 +466,10 @@ def main() -> None:
             body["reason"] = args.inspiration_reason.strip()
         _post(FLASK_URL, json.dumps(body).encode(), token)
         _post(STATS_URL, json.dumps({"players": [{"name": name, "inspiration": True}]}).encode(), token)
-        return
 
     if args.inspiration_spend:
         name = args.inspiration_spend.strip()
         _post(STATS_URL, json.dumps({"players": [{"name": name, "inspiration": False}]}).encode(), token)
-        return
 
     # ── Milestone award/spend (stack-based reward — system-agnostic) ─────────
     # Distinct from --inspiration-award: that one is the binary D&D 5e badge,
@@ -482,24 +478,22 @@ def main() -> None:
     if args.milestone_award:
         name = args.milestone_award.strip()
         label = (args.milestone_label or "Milestone").strip()
-        body = {"milestone_award": name, "text": name, "label": label}
+        m_body: dict = {"milestone_award": name, "text": name, "label": label}
         if args.milestone_reason:
-            body["reason"] = args.milestone_reason.strip()
-        _post(FLASK_URL, json.dumps(body).encode(), token)
+            m_body["reason"] = args.milestone_reason.strip()
+        _post(FLASK_URL, json.dumps(m_body).encode(), token)
         _post(STATS_URL, json.dumps({
             "players": [{"name": name, "_milestone_inc": label}]
         }).encode(), token)
-        return
 
     if args.milestone_spend:
         name = args.milestone_spend.strip()
         label = (args.milestone_label or "Milestone").strip()
-        body = {"milestone_spend": name, "text": name, "label": label}
-        _post(FLASK_URL, json.dumps(body).encode(), token)
+        ms_body: dict = {"milestone_spend": name, "text": name, "label": label}
+        _post(FLASK_URL, json.dumps(ms_body).encode(), token)
         _post(STATS_URL, json.dumps({
             "players": [{"name": name, "_milestone_dec": label}]
         }).encode(), token)
-        return
 
     # ── XP award block ────────────────────────────────────────────────────────
     if args.xp_award:
@@ -515,7 +509,6 @@ def main() -> None:
             rsn   = xp_data.get("reason", "")
             xp_data["summary"] = f"{names} — {amt} XP" + (f" ({rsn})" if rsn else "")
         _post(FLASK_URL, json.dumps({"xp_award": xp_data, "text": xp_data["summary"]}).encode(), token)
-        return
 
     # ── Pre-flight integrity check ────────────────────────────────────────────
     # If a content flag is set but no text arrived on stdin, that's almost


### PR DESCRIPTION
## Summary

`--inspiration-award`, `--inspiration-spend`, `--milestone-award`, `--milestone-spend`, and `--xp-award` previously did an early `return` after POSTing their styled block, dropping any heredoc body bundled in the same call. The stdin-routing block also force-set `text=""` when any award flag was present, so the body was never even read.

Result: callers like `python3 send.py --inspiration-award NAME << ...` broadcast the gold Inspiration block but the narration silently disappeared, forcing a second `send.py` call to publish it.

## Fix

- Read piped stdin under the same `isatty()` gate as stat flags.
- Replace each award-flag `return` with fall-through, so the text-send block at the bottom POSTs the bundled body as a normal chunk after the styled block.

Bundled narration now reliably accompanies its award. Plain award-only calls (no heredoc) are unchanged.

## Test plan

- [x] Syntax: `python3 -m py_compile display/send.py` passes
- [x] Live smoke test against the running display: `--milestone-award X --milestone-label Y --milestone-reason Z` with stdin body — both the styled block AND the narration chunk render in the feed (visually confirmed)
- [x] Award-only calls (no heredoc body) still emit the styled block + stat update without touching `/chunk` for the body
