### PR TITLE
feat: NPC rename + cross-campaign name registry

### DIFF
--- a/SKILL-commands.md
+++ b/SKILL-commands.md
@@ -525,6 +525,35 @@ Read `characters/<name>.md`, display cleanly. If name omitted and one character 
 ## `/dnd npc attitude <name> <shift>`
 Find NPC in npcs.md, shift attitude one step (hostile → unfriendly → neutral → friendly → allied), log reason and date.
 
+## `/dnd npc rename "Old Name" <"New Name" | random> [flags]`
+Rename a character across an entire campaign — `npcs.md`, `npcs-full.md`, `state.md` (every section), `session-log.md`, `graph.json` (node + edges preserved), and `characters/<slug>.md` if `--type pc`. Backs up the campaign first.
+
+Maps to: `python3 ~/.claude/skills/dnd/scripts/npc_rename.py --campaign <current> --old "..." --new "..." [flags]`. Use the currently loaded campaign by default; for explicit-campaign use, pass `--campaign <name>` directly.
+
+Flags:
+- `--random` — pick a name from the bundled fantasy-name corpus (~4800 unique combinations) that isn't already in `~/.claude/dnd/.name_registry.json`. Mutually exclusive with explicit "New Name".
+- `--type npc | pc` (default `npc`) — `pc` also moves the character file and updates the global roster.
+- `--dry-run` — show all hits across files without writing. Always run first for sanity.
+- `--yes` — skip the confirmation prompt.
+- `--include-archive` — also rename in `session-log-archive.md`. **Default is to leave the archive untouched** for historical accuracy and add a one-line audit note at the top: *"`<old>` renamed to `<new>` at S<N>; historical entries below preserve the original name."*
+
+The script always backs up the campaign to `<name>.backup-rename-<old-slug>-YYYYMMDD-HHMMSS/` before any writes. Revert command is printed at the end.
+
+After rename, the name registry is updated: old name marked `retired_from` this campaign with `replaced_by` pointing at the new slug; new name added with this campaign's current session as `first_session`.
+
+## `/dnd registry <subcommand>`
+View and manage the cross-campaign name registry at `~/.claude/dnd/.name_registry.json`. Used by `/dnd npc rename --random` to never reuse a name and (in a follow-up) by `/dnd new` / `/dnd character new` / `/dnd npc <new>` to flag duplicates at creation time.
+
+Maps to: `python3 ~/.claude/skills/dnd/scripts/name_registry.py <subcommand> [args]`.
+
+- `/dnd registry rebuild` — scan every campaign's `npcs.md`, `npcs-full.md`, `characters/*.md`, and `graph.json` (node names); rebuild the registry from canonical sources. Preserves any existing `retired_from` history. Run once on install, then ad hoc when desired.
+- `/dnd registry list [--campaign C] [--type npc|pc]` — print all registry entries; filter by campaign-currently-active or by type.
+- `/dnd registry lookup <name>` — case-insensitive lookup; prints the full entry as JSON.
+- `/dnd registry add --name N --type npc|pc --campaign C --session N` — record a new entry manually (auto-called by `/dnd npc rename`).
+- `/dnd registry retire --name N --campaign C [--replaced-by NEW]` — mark a name as no longer active in a campaign (auto-called by `/dnd npc rename`).
+
+The registry captures **canonical** characters (those in `npcs.md` / `npcs-full.md` / `characters/`). Names that appear only in session-log prose (one-off mentions, throwaway NPCs) are NOT registered — that's deliberate, to avoid banning common names because of incidental use. A future `--include-prose` flag can extend the scan if needed.
+
 ---
 
 ## `/dnd characters`

--- a/scripts/name_registry.py
+++ b/scripts/name_registry.py
@@ -1,0 +1,340 @@
+"""
+name_registry.py — persistent cache of every character name ever used
+across all campaigns under this account.
+
+Storage: <DND_CAMPAIGN_ROOT>/.name_registry.json (defaults to
+~/.claude/dnd/.name_registry.json).
+
+Purpose:
+    1. Detect duplicate-name proposals at /dnd new, /dnd character new,
+       /dnd npc <new> time (consumed by Piece 2 — uniqueness check).
+    2. Power the random-name path of /dnd npc rename (Piece 3) — never
+       pick a name already in the registry.
+    3. Auditable footprint of who's been used where.
+
+Schema per entry (keyed by slug):
+    {
+        "name": "Aldric Voss",
+        "slug": "aldric_voss",
+        "type": "npc" | "pc",
+        "first_campaign": "campaign-name",
+        "first_session": 1,
+        "first_used": "YYYY-MM-DD",
+        "currently_active_in": ["campaign-1", "campaign-2"],
+        "retired_from": [
+            {"campaign": "campaign-name", "replaced_by": "new_slug",
+             "date": "YYYY-MM-DD"}
+        ]
+    }
+
+CLI:
+    python3 name_registry.py rebuild           # scan all campaigns
+    python3 name_registry.py list [--campaign C] [--type npc|pc]
+    python3 name_registry.py lookup <name>     # case-insensitive
+    python3 name_registry.py add --name N --type T --campaign C --session N
+    python3 name_registry.py retire --name N --campaign C [--replaced-by NEW]
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import pathlib
+import re
+import sys
+
+from paths import campaigns_dir, characters_dir, _root
+
+
+def _registry_path() -> pathlib.Path:
+    return _root() / ".name_registry.json"
+
+
+def _today() -> str:
+    return datetime.date.today().isoformat()
+
+
+def slug(name: str) -> str:
+    """Lowercase, snake_case slug. Drop punctuation; collapse whitespace.
+
+    Strips parenthetical content first so 'Vedra Ceth (V.C.)' and
+    'Vedra Ceth' produce the same slug. Strips trailing/leading whitespace.
+    """
+    s = name.strip().lower()
+    s = re.sub(r"\s*\([^)]*\)\s*", " ", s)  # drop parenthetical asides
+    s = re.sub(r"[^\w\s]", "", s)            # drop remaining punctuation
+    s = re.sub(r"\s+", "_", s).strip("_")    # collapse whitespace to _
+    return s
+
+
+def _load() -> dict:
+    p = _registry_path()
+    if not p.exists():
+        return {"version": 1, "updated": _today(), "entries": {}}
+    try:
+        return json.loads(p.read_text())
+    except json.JSONDecodeError:
+        sys.stderr.write(f"name_registry: {p} is corrupt; starting fresh\n")
+        return {"version": 1, "updated": _today(), "entries": {}}
+
+
+def _save(data: dict) -> None:
+    data["updated"] = _today()
+    p = _registry_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+
+
+# ── Scanners ──────────────────────────────────────────────────────────────
+
+_NPCS_TABLE_ROW = re.compile(r"^\|\s*([^|]+?)\s*\|", re.MULTILINE)
+_NPCS_FULL_HEADER = re.compile(r"^### \s*([^\n]+?)\s*$", re.MULTILINE)
+_NPC_HEADER = re.compile(r"^## \s*([^\n]+?)\s*$", re.MULTILINE)
+_CHARACTER_H1 = re.compile(r"^#\s+([^\n]+?)\s*$", re.MULTILINE)
+_SESSION_COUNT = re.compile(r"\*\*Session count:\*\*\s*(\d+)")
+_LAST_SESSION = re.compile(r"\*\*Last session:\*\*\s*(\d{4}-\d{2}-\d{2})")
+_CREATED = re.compile(r"\*\*Created:\*\*\s*(\d{4}-\d{2}-\d{2})")
+
+
+def _campaign_session_count(camp_dir: pathlib.Path) -> int:
+    state = camp_dir / "state.md"
+    if not state.exists():
+        return 0
+    m = _SESSION_COUNT.search(state.read_text(errors="replace"))
+    return int(m.group(1)) if m else 0
+
+
+def _scan_campaign_npcs(camp_dir: pathlib.Path) -> list[str]:
+    """Read npcs.md table column 1 + npcs-full.md ### headers; return names."""
+    names: list[str] = []
+    npcs = camp_dir / "npcs.md"
+    if npcs.exists():
+        for row in _NPCS_TABLE_ROW.finditer(npcs.read_text(errors="replace")):
+            cell = row.group(1).strip()
+            # Skip header rows ("Name") and divider rows ("---")
+            if not cell or cell.lower() in {"name"} or set(cell) <= {"-", " ", ":"}:
+                continue
+            names.append(cell)
+    full = camp_dir / "npcs-full.md"
+    if full.exists():
+        for h in _NPCS_FULL_HEADER.finditer(full.read_text(errors="replace")):
+            names.append(h.group(1).strip())
+        for h in _NPC_HEADER.finditer(full.read_text(errors="replace")):
+            names.append(h.group(1).strip())
+    return names
+
+
+def _scan_campaign_pcs(camp_dir: pathlib.Path) -> list[str]:
+    """Read characters/*.md H1 line; return PC names."""
+    pcs: list[str] = []
+    char_dir = camp_dir / "characters"
+    if not char_dir.exists():
+        return pcs
+    for f in sorted(char_dir.glob("*.md")):
+        text = f.read_text(errors="replace")
+        m = _CHARACTER_H1.search(text)
+        if m:
+            pcs.append(m.group(1).strip())
+    return pcs
+
+
+def _scan_campaign_graph(camp_dir: pathlib.Path) -> list[tuple[str, str]]:
+    """Read graph.json node names + types — returns [(name, type), ...]."""
+    g = camp_dir / "graph.json"
+    if not g.exists():
+        return []
+    try:
+        data = json.loads(g.read_text())
+    except json.JSONDecodeError:
+        return []
+    out = []
+    for node in data.get("nodes", []):
+        name = node.get("name") or node.get("label")
+        ntype = node.get("type", "npc")
+        # Only collect npc/pc nodes — places/factions/threads aren't characters
+        if name and ntype in {"npc", "pc"}:
+            out.append((name, ntype))
+    return out
+
+
+# ── Operations ────────────────────────────────────────────────────────────
+
+def _ensure_entry(entries: dict, name: str, ntype: str,
+                  campaign: str, session: int) -> dict:
+    s = slug(name)
+    if s in entries:
+        e = entries[s]
+        # Update active list
+        if campaign not in e.get("currently_active_in", []):
+            e.setdefault("currently_active_in", []).append(campaign)
+        return e
+    entries[s] = {
+        "name": name,
+        "slug": s,
+        "type": ntype,
+        "first_campaign": campaign,
+        "first_session": session,
+        "first_used": _today(),
+        "currently_active_in": [campaign],
+        "retired_from": [],
+    }
+    return entries[s]
+
+
+def rebuild() -> dict:
+    """Walk every campaign and populate the registry from scratch.
+
+    Existing retire-from history is preserved on a best-effort basis if
+    the slug matches; otherwise rebuild starts fresh (use --keep-history
+    to preserve all retire records — see CLI flag).
+    """
+    data = _load()
+    old_entries = data.get("entries", {})
+    new_entries: dict = {}
+
+    cd = campaigns_dir()
+    if not cd.exists():
+        return {"campaigns": 0, "entries": 0}
+
+    campaign_count = 0
+    for camp in sorted(cd.iterdir()):
+        if not camp.is_dir() or camp.name.startswith("."):
+            continue
+        if ".backup-" in camp.name:
+            continue
+        campaign_count += 1
+        sess = _campaign_session_count(camp)
+
+        for name in _scan_campaign_npcs(camp):
+            _ensure_entry(new_entries, name, "npc", camp.name, sess)
+        for name in _scan_campaign_pcs(camp):
+            _ensure_entry(new_entries, name, "pc", camp.name, sess)
+        for name, ntype in _scan_campaign_graph(camp):
+            _ensure_entry(new_entries, name, ntype, camp.name, sess)
+
+    # Preserve retire-from history from old registry where slug matches
+    for s, old_e in old_entries.items():
+        if s in new_entries and old_e.get("retired_from"):
+            new_entries[s]["retired_from"] = old_e["retired_from"]
+
+    data["entries"] = new_entries
+    _save(data)
+    return {"campaigns": campaign_count, "entries": len(new_entries)}
+
+
+def add(name: str, ntype: str, campaign: str, session: int) -> dict:
+    data = _load()
+    entry = _ensure_entry(data["entries"], name, ntype, campaign, session)
+    _save(data)
+    return entry
+
+
+def retire(name: str, campaign: str, replaced_by: str | None = None) -> dict | None:
+    data = _load()
+    s = slug(name)
+    if s not in data["entries"]:
+        return None
+    e = data["entries"][s]
+    e["currently_active_in"] = [c for c in e.get("currently_active_in", []) if c != campaign]
+    e.setdefault("retired_from", []).append({
+        "campaign": campaign,
+        "replaced_by": slug(replaced_by) if replaced_by else None,
+        "date": _today(),
+    })
+    _save(data)
+    return e
+
+
+def lookup(name: str) -> dict | None:
+    data = _load()
+    return data["entries"].get(slug(name))
+
+
+def list_entries(campaign: str | None = None,
+                 ntype: str | None = None) -> list[dict]:
+    data = _load()
+    out = []
+    for e in data["entries"].values():
+        if campaign and campaign not in e.get("currently_active_in", []):
+            continue
+        if ntype and e.get("type") != ntype:
+            continue
+        out.append(e)
+    return sorted(out, key=lambda x: x["name"].lower())
+
+
+def all_taken_slugs() -> set[str]:
+    """Used by random-name path to exclude every name ever seen."""
+    data = _load()
+    return set(data["entries"].keys())
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("rebuild", help="scan all campaigns, populate registry")
+
+    pl = sub.add_parser("list", help="list registry entries")
+    pl.add_argument("--campaign", help="filter to this campaign's active set")
+    pl.add_argument("--type", choices=["npc", "pc"], help="filter by type")
+
+    pk = sub.add_parser("lookup", help="case-insensitive lookup by name")
+    pk.add_argument("name")
+
+    pa = sub.add_parser("add", help="record a new name")
+    pa.add_argument("--name", required=True)
+    pa.add_argument("--type", choices=["npc", "pc"], default="npc")
+    pa.add_argument("--campaign", required=True)
+    pa.add_argument("--session", type=int, default=1)
+
+    pr = sub.add_parser("retire", help="mark a name as retired in a campaign")
+    pr.add_argument("--name", required=True)
+    pr.add_argument("--campaign", required=True)
+    pr.add_argument("--replaced-by", help="slug of replacement entry")
+
+    args = p.parse_args()
+
+    if args.cmd == "rebuild":
+        result = rebuild()
+        print(f"name_registry: scanned {result['campaigns']} campaigns; "
+              f"{result['entries']} unique names recorded")
+        print(f"  registry: {_registry_path()}")
+        return 0
+
+    if args.cmd == "list":
+        entries = list_entries(campaign=args.campaign, ntype=args.type)
+        for e in entries:
+            active = ",".join(e.get("currently_active_in", [])) or "(retired everywhere)"
+            print(f"  {e['type']:3s}  {e['name']:30s}  first: {e['first_campaign']} S{e['first_session']}  active: {active}")
+        print(f"\n  total: {len(entries)} entries")
+        return 0
+
+    if args.cmd == "lookup":
+        e = lookup(args.name)
+        if not e:
+            print(f"  no entry for '{args.name}'")
+            return 1
+        print(json.dumps(e, indent=2, ensure_ascii=False))
+        return 0
+
+    if args.cmd == "add":
+        e = add(args.name, args.type, args.campaign, args.session)
+        print(json.dumps(e, indent=2, ensure_ascii=False))
+        return 0
+
+    if args.cmd == "retire":
+        e = retire(args.name, args.campaign, args.replaced_by)
+        if not e:
+            print(f"  no entry for '{args.name}'")
+            return 1
+        print(json.dumps(e, indent=2, ensure_ascii=False))
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/npc_rename.py
+++ b/scripts/npc_rename.py
@@ -1,0 +1,368 @@
+"""
+npc_rename.py — rename a character (NPC or PC) across an entire campaign.
+
+Updates every file the name appears in, atomically, with backup-first safety:
+  - npcs.md, npcs-full.md
+  - state.md (every section — Current Situation, Live State Flags, Active
+    Quests, Recent Events, Faction Moves, Continuity Archive, DM Notes)
+  - session-log.md (current sessions)
+  - characters/<slug>.md (renames file too if PC) + global roster mirror
+  - graph.json (renames node by name; edges preserved — they reference IDs)
+
+session-log-archive.md is left untouched by default (historical accuracy)
+unless --include-archive is passed. A one-line audit note is added to the
+archive top noting the rename.
+
+Usage:
+    python3 npc_rename.py --campaign C --old "Old Name" --new "New Name"
+    python3 npc_rename.py --campaign C --old "Old Name" --random
+    python3 npc_rename.py --campaign C --old "Old Name" --new "New" --dry-run
+    python3 npc_rename.py --campaign C --old "Old Name" --new "New" --yes
+    python3 npc_rename.py --campaign C --old "Old Name" --new "New" --type pc
+    python3 npc_rename.py --campaign C --old "Old Name" --new "New" --include-archive
+
+Flags:
+    --dry-run         show hits without writing
+    --yes             skip confirmation prompt
+    --type            npc (default) | pc — pc rename also moves the
+                      character file and updates the global roster
+    --include-archive also rename in session-log-archive.md (default: skip
+                      to preserve historical accuracy; an audit note is
+                      added to the archive top either way)
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import pathlib
+import random
+import re
+import shutil
+import subprocess
+import sys
+
+from paths import find_campaign, characters_dir, _root
+from name_registry import slug, all_taken_slugs, add as registry_add, retire as registry_retire
+
+
+# ── Embedded fantasy-name corpus ──────────────────────────────────────────
+# 80 first × 60 last = 4800 unique combinations. Sourced from common public-
+# domain fantasy name patterns; no copyrighted material.
+_FIRST = [
+    "Aelric", "Aldon", "Alric", "Anselm", "Arden", "Bael", "Branwen", "Caelum",
+    "Caen", "Cassian", "Cedric", "Corran", "Corvin", "Daric", "Drest", "Eamon",
+    "Elen", "Ember", "Erland", "Eryn", "Fenric", "Galen", "Gareth", "Gennar",
+    "Hadrian", "Halric", "Hartwin", "Idris", "Iren", "Jovan", "Kael", "Kerith",
+    "Lael", "Lirien", "Lorcan", "Lyra", "Maerin", "Mairwen", "Marrick", "Merrin",
+    "Naren", "Nerys", "Niall", "Olen", "Oren", "Perrin", "Quinn", "Rael",
+    "Renwick", "Rhydian", "Rilen", "Rorik", "Saern", "Selwyn", "Senna", "Sevren",
+    "Sorin", "Talin", "Tamsyn", "Theron", "Tiernan", "Tordis", "Trevin", "Ulric",
+    "Valen", "Vellin", "Verra", "Wendel", "Wren", "Xira", "Yael", "Yarrick",
+    "Ysolde", "Zephir", "Auren", "Brel", "Cyrith", "Dorvel", "Fellan", "Hesta",
+]
+
+_LAST = [
+    "Ashbourne", "Bellweather", "Blackmoor", "Brackenhold", "Brightspire", "Carrowfell",
+    "Castermane", "Cinderhold", "Coldspring", "Crowmere", "Dalebrook", "Darkmoor",
+    "Drystone", "Edgewater", "Embervale", "Fairwynd", "Fenlocke", "Fellscarp",
+    "Frostgale", "Glasswain", "Greybarrow", "Hallowind", "Harrowmere", "Hartwell",
+    "Hollowstride", "Innesglen", "Ironholt", "Karnwell", "Larkmere", "Lockmoor",
+    "Marrowfen", "Mistwarden", "Nightbrook", "Oakhaven", "Pellsworth", "Quintain",
+    "Ravenhall", "Reedstrand", "Rookwell", "Sablecroft", "Saltmere", "Silverbrook",
+    "Stormcrest", "Tallowmere", "Thornwell", "Tindalbrook", "Underwich", "Vaelmoor",
+    "Vexworth", "Whitethorn", "Wilderbrook", "Yarrowfield", "Zorrenglade", "Brackleaf",
+    "Coalwarden", "Drosspike", "Greengrave", "Hexmere", "Lampwood", "Pinegate",
+]
+
+
+def random_name(taken_slugs: set[str]) -> str:
+    """Pick first + last from corpus; reject if slug already taken; up to 50 retries.
+
+    Falls back to a numerical suffix if the rare draw exhausts the search.
+    """
+    for _ in range(50):
+        candidate = f"{random.choice(_FIRST)} {random.choice(_LAST)}"
+        if slug(candidate) not in taken_slugs:
+            return candidate
+    # Fallback — suffix with random 3-digit number
+    return f"{random.choice(_FIRST)} {random.choice(_LAST)}-{random.randint(100, 999)}"
+
+
+# ── File-set discovery ────────────────────────────────────────────────────
+
+_TEXT_FILES_ALWAYS = ["npcs.md", "npcs-full.md", "state.md",
+                      "session-log.md", "world.md"]
+_TEXT_FILES_OPTIONAL = ["session-log-archive.md"]
+
+
+def _files_to_scan(camp_dir: pathlib.Path,
+                   include_archive: bool) -> list[pathlib.Path]:
+    out = []
+    for name in _TEXT_FILES_ALWAYS:
+        f = camp_dir / name
+        if f.exists():
+            out.append(f)
+    if include_archive:
+        for name in _TEXT_FILES_OPTIONAL:
+            f = camp_dir / name
+            if f.exists():
+                out.append(f)
+    return out
+
+
+# ── Hit detection ─────────────────────────────────────────────────────────
+
+def _whole_word_pattern(name: str) -> re.Pattern:
+    """Match the full name as a whole-word sequence; case-sensitive.
+
+    Word-boundary aware so 'Sera' doesn't match inside 'Seraphim' but does
+    match in 'Sera Voss' or 'Sera,'. Multi-word names are joined with a
+    flexible whitespace pattern so 'Aldric  Voss' (double space) still matches.
+    """
+    parts = [re.escape(p) for p in name.strip().split()]
+    body = r"\s+".join(parts)
+    return re.compile(rf"\b{body}\b")
+
+
+def find_hits(camp_dir: pathlib.Path, old: str,
+              include_archive: bool) -> dict[pathlib.Path, list[tuple[int, str]]]:
+    """Scan all relevant files; return {file: [(line_num, line), ...]}."""
+    pat = _whole_word_pattern(old)
+    hits: dict[pathlib.Path, list[tuple[int, str]]] = {}
+    for f in _files_to_scan(camp_dir, include_archive):
+        try:
+            text = f.read_text(errors="replace")
+        except OSError:
+            continue
+        matches: list[tuple[int, str]] = []
+        for n, line in enumerate(text.splitlines(), start=1):
+            if pat.search(line):
+                matches.append((n, line.rstrip()))
+        if matches:
+            hits[f] = matches
+    return hits
+
+
+# ── Apply ─────────────────────────────────────────────────────────────────
+
+def apply_text_rename(path: pathlib.Path, old: str, new: str) -> int:
+    """Whole-word replace old → new in path. Returns replacement count."""
+    pat = _whole_word_pattern(old)
+    text = path.read_text(errors="replace")
+    new_text, n = pat.subn(new, text)
+    if n > 0:
+        path.write_text(new_text)
+    return n
+
+
+def apply_graph_rename(graph_path: pathlib.Path, old: str, new: str) -> bool:
+    """Rename node whose .name == old → new. Edges reference node IDs so
+    they're untouched. Also rewrites the slug-prefixed node id if present.
+
+    Returns True if a node was renamed.
+    """
+    if not graph_path.exists():
+        return False
+    try:
+        data = json.loads(graph_path.read_text())
+    except json.JSONDecodeError:
+        return False
+    old_slug = slug(old)
+    new_slug = slug(new)
+    renamed = False
+    nodes = data.get("nodes", [])
+    id_remap: dict[str, str] = {}
+    for node in nodes:
+        if node.get("name") == old:
+            node["name"] = new
+            # Remap node id if it follows the type_slug convention
+            old_id = node.get("id", "")
+            ntype = node.get("type", "npc")
+            expected_old_id = f"{ntype}_{old_slug}"
+            if old_id == expected_old_id:
+                new_id = f"{ntype}_{new_slug}"
+                node["id"] = new_id
+                id_remap[old_id] = new_id
+            renamed = True
+    # Rewrite edges that reference renamed node ids
+    for edge in data.get("edges", []):
+        for k in ("from", "to"):
+            if edge.get(k) in id_remap:
+                edge[k] = id_remap[edge[k]]
+    if renamed:
+        graph_path.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+    return renamed
+
+
+def add_archive_audit_note(camp_dir: pathlib.Path, old: str, new: str,
+                           session: int) -> bool:
+    """Add a one-line audit note at the top of session-log-archive.md."""
+    archive = camp_dir / "session-log-archive.md"
+    if not archive.exists():
+        return False
+    text = archive.read_text(errors="replace")
+    today = datetime.date.today().isoformat()
+    note = (f"<!-- rename audit {today}: '{old}' renamed to '{new}' "
+            f"at S{session}; historical entries below preserve the original name -->\n")
+    if note.split(": ", 1)[1].split(" at S")[0] in text:
+        # Already noted — don't double-note
+        return False
+    archive.write_text(note + text)
+    return True
+
+
+# ── Main flow ─────────────────────────────────────────────────────────────
+
+def _read_session_count(camp_dir: pathlib.Path) -> int:
+    state = camp_dir / "state.md"
+    if not state.exists():
+        return 0
+    m = re.search(r"\*\*Session count:\*\*\s*(\d+)",
+                  state.read_text(errors="replace"))
+    return int(m.group(1)) if m else 0
+
+
+def _backup(camp_dir: pathlib.Path) -> pathlib.Path:
+    ts = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+    target = camp_dir.with_name(f"{camp_dir.name}.backup-rename-{ts}")
+    shutil.copytree(camp_dir, target)
+    return target
+
+
+def _confirm(prompt: str) -> bool:
+    try:
+        ans = input(prompt + " [y/n] ").strip().lower()
+    except EOFError:
+        return False
+    return ans in {"y", "yes"}
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--campaign", required=True)
+    p.add_argument("--old", required=True, help="existing character name")
+    grp = p.add_mutually_exclusive_group(required=True)
+    grp.add_argument("--new", help="explicit new name")
+    grp.add_argument("--random", action="store_true",
+                     help="pick a registry-safe random name")
+    p.add_argument("--type", choices=["npc", "pc"], default="npc")
+    p.add_argument("--dry-run", action="store_true",
+                   help="show hits without writing")
+    p.add_argument("--yes", action="store_true",
+                   help="skip confirmation prompt")
+    p.add_argument("--include-archive", action="store_true",
+                   help="also rename in session-log-archive.md "
+                        "(default: leave historical text intact)")
+
+    args = p.parse_args()
+
+    camp_dir = find_campaign(args.campaign)
+    if not camp_dir.exists():
+        print(f"npc_rename: campaign '{args.campaign}' not found at {camp_dir}",
+              file=sys.stderr)
+        return 1
+
+    # Resolve --new (explicit or random)
+    if args.random:
+        taken = all_taken_slugs()
+        new_name = random_name(taken)
+        print(f"  --random picked: {new_name}")
+    else:
+        new_name = args.new
+
+    # Find hits
+    hits = find_hits(camp_dir, args.old, args.include_archive)
+    if not hits:
+        print(f"npc_rename: no occurrences of '{args.old}' found in {camp_dir.name}",
+              file=sys.stderr)
+        return 1
+
+    total_lines = sum(len(v) for v in hits.values())
+    print(f"\n=== rename plan: '{args.old}' → '{new_name}' in {camp_dir.name} ===")
+    print(f"  files affected : {len(hits)}")
+    print(f"  total matches  : {total_lines}\n")
+    for f, matches in hits.items():
+        print(f"  {f.name}: {len(matches)} matches")
+        for ln, line in matches[:3]:
+            preview = line if len(line) <= 120 else line[:117] + "..."
+            print(f"    L{ln}: {preview}")
+        if len(matches) > 3:
+            print(f"    ... and {len(matches) - 3} more")
+    # Graph rename preview
+    g = camp_dir / "graph.json"
+    if g.exists():
+        try:
+            data = json.loads(g.read_text())
+            graph_match = any(n.get("name") == args.old for n in data.get("nodes", []))
+            if graph_match:
+                print(f"  graph.json: 1 node will be renamed (edges preserved)")
+        except json.JSONDecodeError:
+            pass
+    # PC file rename preview
+    if args.type == "pc":
+        old_pc = camp_dir / "characters" / f"{slug(args.old)}.md"
+        if old_pc.exists():
+            print(f"  characters/{slug(args.old)}.md → characters/{slug(new_name)}.md")
+            print(f"  WARNING: PC rename also updates global roster at "
+                  f"{characters_dir() / (slug(args.old) + '.md')}")
+
+    if args.dry_run:
+        print("\n  --dry-run set; no writes performed.")
+        return 0
+
+    if not args.yes:
+        if not _confirm("\nApply rename (with backup)?"):
+            print("  cancelled.")
+            return 1
+
+    # Backup
+    backup = _backup(camp_dir)
+    print(f"\n  backup: {backup}")
+
+    # Apply text renames
+    total_replacements = 0
+    for f in list(hits.keys()):
+        n = apply_text_rename(f, args.old, new_name)
+        print(f"    {f.name}: {n} replacements")
+        total_replacements += n
+
+    # Apply graph rename
+    if g.exists():
+        if apply_graph_rename(g, args.old, new_name):
+            print(f"    graph.json: node renamed")
+
+    # PC file rename
+    if args.type == "pc":
+        old_pc = camp_dir / "characters" / f"{slug(args.old)}.md"
+        if old_pc.exists():
+            new_pc = camp_dir / "characters" / f"{slug(new_name)}.md"
+            old_pc.rename(new_pc)
+            print(f"    characters/{slug(args.old)}.md → characters/{slug(new_name)}.md")
+            # Mirror to global roster
+            global_old = characters_dir() / f"{slug(args.old)}.md"
+            global_new = characters_dir() / f"{slug(new_name)}.md"
+            if global_old.exists():
+                shutil.copy(new_pc, global_new)
+                global_old.unlink()
+                print(f"    global roster updated")
+
+    # Archive audit note (only if NOT including archive in rename)
+    if not args.include_archive:
+        sess = _read_session_count(camp_dir)
+        if add_archive_audit_note(camp_dir, args.old, new_name, sess):
+            print(f"    session-log-archive.md: audit note added at top")
+
+    # Update name registry
+    sess = _read_session_count(camp_dir)
+    registry_retire(args.old, args.campaign, replaced_by=new_name)
+    registry_add(new_name, args.type, args.campaign, sess)
+    print(f"    name_registry: '{args.old}' retired, '{new_name}' added")
+
+    print(f"\n  done. {total_replacements} text replacements + graph + registry updates.")
+    print(f"  To revert: rm -rf '{camp_dir}' && mv '{backup}' '{camp_dir}'")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two new scripts + SKILL-commands.md docs addressing duplicate-name fatigue across long-running multi-campaign play.

**`scripts/name_registry.py`** — persistent cache of every canonical character name across all campaigns. Stored at `<DND_CAMPAIGN_ROOT>/.name_registry.json`. Tracks first-used campaign / session / date, currently-active campaigns, retired-from history with replacement pointers. Subcommands: `rebuild | list | lookup | add | retire`.

**`scripts/npc_rename.py`** — rename a character across an entire campaign atomically with backup-first safety:
- `npcs.md`, `npcs-full.md`, `state.md` (every section), `session-log.md`, `world.md`
- `graph.json` node + edges preserved (edges reference node IDs)
- `characters/<slug>.md` if `--type pc`, plus global roster mirror
- `session-log-archive.md` left untouched by default for historical accuracy; audit note added at top
- `--random` picks from a bundled fantasy-name corpus (~4800 unique combinations, public-domain) and rejects any slug already in the name registry

Smoke-tested on a 13-campaign installation (registry rebuild → 67 unique entries; rename `--dry-run` → 6 hits across 2 files plus 1 graph node).

Piece 2 of the original design (creation-time uniqueness check at `/dnd new` / `/dnd character new` / `/dnd npc <new>`) is intentionally deferred — additive over this foundation, lower urgency since rename covers the 'fix duplicates after the fact' use case.