### PR TITLE
feat: registry check + prose-scan + npc_rename hardening

### DIFF
--- a/SKILL-commands.md
+++ b/SKILL-commands.md
@@ -456,7 +456,13 @@ Read `~/.claude/dnd/campaigns/*/state.md`, print summary table: campaign name | 
 ---
 
 ## `/dnd character new [campaign-name]`
-1. Ask: name, race, class, background
+1. Ask: name, race, class, background.
+
+   **Name uniqueness check (added 2026-05-07):** after the player gives a name, run `python3 ~/.claude/skills/dnd/scripts/name_registry.py check "<name>"`. If exit code is 1 (duplicate), the script prints which prior campaign / session used the name; surface that to the player as a non-blocking warning:
+
+   > *"That name was first used in `<first_campaign>` S`<first_session>`. Reuse if it's intentional, or pick a different name. Continue with `<name>`?"*
+
+   If the player confirms, proceed. If they want to change, return to the name prompt. After the character is fully created (step 9, after global-roster mirror), call `name_registry.py add --name "<name>" --type pc --campaign <name> --session <current>` to record it.
 2. Ask: *"In a sentence, what should the DM know about [Name]?"*
    - If answered: derive ONE pillar — **Bond**, **Flaw**, **Ideal**, or **Goal** (whichever fits best). Store both the raw sentence and derived pillar in `## Character Pillar`.
    - If skipped: leave `## Character Pillar` blank. Do not invent one. Do not re-prompt.
@@ -522,6 +528,10 @@ Read `characters/<name>.md`, display cleanly. If name omitted and one character 
 - Existing → read full entry from npcs-full.md (search by name), portray in character with voice/quirk
 - New → generate full entry: role, CR-appropriate stats, demeanor, motivation, secret, speech quirk, faction (or "independent"), current goal, schedule, all four personality axes, ≥2 relationships to existing NPCs. Default attitude neutral. Append full entry to npcs-full.md; add one-line summary row to npcs.md index.
 
+  **Name uniqueness check (added 2026-05-07):** before generating, run `python3 ~/.claude/skills/dnd/scripts/name_registry.py check "<proposed-name>"`. If duplicate (exit 1), surface the prior use to the DM and offer either: (a) proceed with the duplicate (some scenarios want recurring names — a Voss reference can be deliberate); or (b) regenerate with a different name. Whichever path is chosen, after the NPC is added to npcs.md / npcs-full.md, call `name_registry.py add --name "<name>" --type npc --campaign <name> --session <current>` to record the entry.
+
+  When **/dnd new** generates a batch of NPCs during world-gen, run the check on each generated name in the same loop: if duplicate, regenerate that name (re-prompt the LLM with the prior name added to a "do-not-pick" exclusion list). After world-gen completes, batch-call `name_registry.py add` for every accepted NPC.
+
 ## `/dnd npc attitude <name> <shift>`
 Find NPC in npcs.md, shift attitude one step (hostile → unfriendly → neutral → friendly → allied), log reason and date.
 
@@ -546,13 +556,19 @@ View and manage the cross-campaign name registry at `~/.claude/dnd/.name_registr
 
 Maps to: `python3 ~/.claude/skills/dnd/scripts/name_registry.py <subcommand> [args]`.
 
-- `/dnd registry rebuild` — scan every campaign's `npcs.md`, `npcs-full.md`, `characters/*.md`, and `graph.json` (node names); rebuild the registry from canonical sources. Preserves any existing `retired_from` history. Run once on install, then ad hoc when desired.
-- `/dnd registry list [--campaign C] [--type npc|pc]` — print all registry entries; filter by campaign-currently-active or by type.
+- `/dnd registry rebuild [--include-prose]` — scan every campaign's `npcs.md`, `npcs-full.md`, `characters/*.md`, and `graph.json` (node names); rebuild the registry from canonical sources. Preserves any existing `retired_from` history. Run once on install, then ad hoc when desired.
+
+  **`--include-prose` (added 2026-05-07, opt-in):** also scan `session-log.md` and `session-log-archive.md` for capitalized 2–3-word sequences (likely-name patterns). Filtered against a stopword list (places, factions, mechanic words like "Ben Stealth", sentence starts) but **regex-based extraction is inherently noisy** — typically 5–15× more entries than canonical, with maybe 10–20% real catches. Tagged `source: prose` to distinguish; query with `/dnd registry list --source prose` to manually review and prune. For high-quality prose extraction, the future move is LLM-backed (similar to `/dnd graph extract`).
+
+- `/dnd registry list [--campaign C] [--type npc|pc] [--source canonical|prose]` — print all registry entries; filter by campaign-currently-active, type, or source.
 - `/dnd registry lookup <name>` — case-insensitive lookup; prints the full entry as JSON.
-- `/dnd registry add --name N --type npc|pc --campaign C --session N` — record a new entry manually (auto-called by `/dnd npc rename`).
+- `/dnd registry check <name> [--json]` — check whether a proposed name collides with the registry. Exit 0 if unique, 1 if duplicate. Severity (`warn` default, `strict` opt-in via `<DND_CAMPAIGN_ROOT>/.name_registry_config.json`) controls whether duplicates are reported as warnings or hard refusals. Used by `/dnd new`, `/dnd character new`, `/dnd npc <new>` procedures.
+- `/dnd registry add --name N --type npc|pc --campaign C --session N` — record a new entry manually (auto-called by `/dnd npc rename` and the creation-time uniqueness hooks).
 - `/dnd registry retire --name N --campaign C [--replaced-by NEW]` — mark a name as no longer active in a campaign (auto-called by `/dnd npc rename`).
 
-The registry captures **canonical** characters (those in `npcs.md` / `npcs-full.md` / `characters/`). Names that appear only in session-log prose (one-off mentions, throwaway NPCs) are NOT registered — that's deliberate, to avoid banning common names because of incidental use. A future `--include-prose` flag can extend the scan if needed.
+The registry by default captures **canonical** characters (those in `npcs.md` / `npcs-full.md` / `characters/` / graph.json node names). Names that appear only in session-log prose (one-off mentions, throwaway NPCs, skill-check labels) are NOT registered by default — that's deliberate, to avoid banning common names because of incidental use. The `--include-prose` flag is opt-in for users who want the broader (noisier) view.
+
+**Severity config:** create `~/.claude/dnd/.name_registry_config.json` with `{"severity": "strict"}` to make all duplicate detections refuse-by-default rather than warn-and-allow. Set to `"none"` to disable checks entirely (registry rebuild and rename still work).
 
 ---
 

--- a/scripts/name_registry.py
+++ b/scripts/name_registry.py
@@ -251,13 +251,16 @@ def lookup(name: str) -> dict | None:
 
 
 def list_entries(campaign: str | None = None,
-                 ntype: str | None = None) -> list[dict]:
+                 ntype: str | None = None,
+                 source: str | None = None) -> list[dict]:
     data = _load()
     out = []
     for e in data["entries"].values():
         if campaign and campaign not in e.get("currently_active_in", []):
             continue
         if ntype and e.get("type") != ntype:
+            continue
+        if source and e.get("source", "canonical") != source:
             continue
         out.append(e)
     return sorted(out, key=lambda x: x["name"].lower())
@@ -269,20 +272,244 @@ def all_taken_slugs() -> set[str]:
     return set(data["entries"].keys())
 
 
+def check(name: str) -> dict:
+    """Check whether a proposed name collides with the registry.
+
+    Returns:
+        {
+            "name": str,                # the proposed name (as given)
+            "is_duplicate": bool,
+            "entry": dict | None,       # the existing entry if duplicate
+            "severity": "none" | "warn" | "strict",
+            "message": str,             # human-readable summary
+        }
+
+    Severity is read from `<DND_CAMPAIGN_ROOT>/.name_registry_config.json`
+    (key `severity`); defaults to `"warn"`. `"none"` skips the check entirely
+    (returns is_duplicate=False even when dup); `"warn"` reports but allows;
+    `"strict"` reports and recommends abort.
+    """
+    cfg_path = _root() / ".name_registry_config.json"
+    severity = "warn"
+    if cfg_path.exists():
+        try:
+            cfg = json.loads(cfg_path.read_text())
+            severity = cfg.get("severity", "warn")
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    if severity == "none":
+        return {"name": name, "is_duplicate": False, "entry": None,
+                "severity": severity, "message": "registry check disabled"}
+
+    e = lookup(name)
+    if not e:
+        return {"name": name, "is_duplicate": False, "entry": None,
+                "severity": severity,
+                "message": f"'{name}' is unique — safe to use"}
+
+    where = ", ".join(e.get("currently_active_in", [])) or "(retired everywhere)"
+    src = e.get("source", "canonical")
+    msg = (f"'{name}' was first used in {e['first_campaign']} S{e['first_session']} "
+           f"({src}); currently active in: {where}")
+    return {"name": name, "is_duplicate": True, "entry": e,
+            "severity": severity, "message": msg}
+
+
+# ── Prose scan (--include-prose) ──────────────────────────────────────────
+
+# Match capitalized 2-3 word sequences as candidate proper nouns.
+_PROSE_NAME_PAT = re.compile(r"\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,2})\b")
+
+# Bigram/trigram stopwords — common phrases that look like names but aren't.
+# Add more as you encounter false positives.
+_PROSE_STOP_PHRASES = {
+    "Pale Court", "Muted Order", "Tithe Ledger", "Three Wells",
+    "Marble Stairs", "Ennis Lane", "Coffin Lane", "Carver Lane",
+    "Tannerway Lane", "Felk Lane", "Wick Lane", "Maret Street",
+    "Coppergate Letter", "Speak with Dead", "Detect Magic",
+    "Fog Cloud", "Wild Shape", "Hand of the Tower", "Bell and Hardrock",
+    "Sand Bell", "Hit Dice", "Long Rest", "Short Rest",
+    "Day Six", "Day Seven", "Day Eight", "Lower Archive",
+    "Highward District", "Pillar Quarter", "Ledger Quarter",
+    "Veiled Stair", "Rennick Family", "Greengate", "Veldrath",
+    "Plan A", "Plan B", "Plan C", "Three Names", "Three Truths",
+    "World State", "Faction Moves", "Live State", "Continuity Archive",
+    "Recent Events", "Active Quests", "Open Threads", "Session Flags",
+    "Campaign Arc", "DM Notes", "DM Style", "Pale Court", "Wood Elf",
+    "Circle of Spores", "Hand of the Tower", "Threadbare", "Hierarch Watch",
+    "Hollins", "Erynn Vaude", "Vehn Dral",
+}
+
+# Single-word common-noun starts that masquerade as names — first word
+# patterns to drop entirely.
+_PROSE_STOP_FIRST_WORDS = {
+    "The", "A", "An", "This", "That", "These", "Those",
+    "Day", "Night", "Morning", "Evening", "Bell",
+    "Plan", "Stage", "Phase", "Round", "Turn",
+    "Chapter", "Section", "Step", "Beat", "Act",
+    "Substitution", "Disruption", "Compact",
+}
+
+
+def _scan_prose(camp_dir: pathlib.Path,
+                canonical_first_words: set[str]) -> list[str]:
+    """Return candidate prose-only names from session-log files.
+
+    Filtering layers (each cuts another category of false positives):
+      - exact match against _PROSE_STOP_PHRASES
+      - first word in _PROSE_STOP_FIRST_WORDS (sentence starts, structural)
+      - first word matches a canonical PC's first name (catches "Ben
+        Healing", "Kat Stealth" — skill-check patterns, not NPCs)
+      - second word is a known D&D mechanic / spell / skill word
+        (Healing, Insight, Stealth, Persuasion, Medicine, Wild, Detect,
+        Fog, Speak, Shape, Word, Cure, Mass, etc.)
+      - candidate appears in canonical entries (already known)
+    """
+    canonical_lower = {w.lower() for w in canonical_first_words}
+    candidates: set[str] = set()
+    for fname in ("session-log.md", "session-log-archive.md"):
+        f = camp_dir / fname
+        if not f.exists():
+            continue
+        text = f.read_text(errors="replace")
+        for m in _PROSE_NAME_PAT.finditer(text):
+            cand = m.group(1).strip()
+            if cand in _PROSE_STOP_PHRASES:
+                continue
+            words = cand.split()
+            first, second = words[0], words[1]
+            if first in _PROSE_STOP_FIRST_WORDS:
+                continue
+            # Skip "PC-name + skill/spell/mechanic" patterns
+            if first.lower() in canonical_lower:
+                continue
+            if second in _DND_MECHANIC_WORDS:
+                continue
+            # Skip if any word looks like a roll outcome (digit-suffix)
+            if any(w.endswith(tuple(str(d) for d in range(10))) for w in words):
+                continue
+            candidates.add(cand)
+    return sorted(candidates)
+
+
+# D&D mechanic words that appear capitalized but aren't NPC name parts.
+# Used to filter out "Ben Healing Word", "Kat Stealth", "Ben Medicine 25" etc.
+_DND_MECHANIC_WORDS = {
+    "Healing", "Cure", "Detect", "Speak", "Wild", "Fog", "Mass", "Word",
+    "Bless", "Bane", "Shield", "Hold", "Charm", "Sleep", "Sacred",
+    "Insight", "Stealth", "Persuasion", "Medicine", "Investigation",
+    "Perception", "Arcana", "History", "Religion", "Nature", "Survival",
+    "Athletics", "Acrobatics", "Deception", "Intimidation", "Performance",
+    "Sleight", "Animal", "Initiative", "Stealth", "Fog",
+    "Long", "Short", "Hit", "Spell", "Cantrip", "Action", "Bonus",
+    "Reaction", "Concentration", "Damage", "Saving",
+    "Strength", "Dexterity", "Constitution", "Intelligence", "Wisdom", "Charisma",
+    "STR", "DEX", "CON", "INT", "WIS", "CHA",
+    # Common verbs/nouns that capitalize at sentence start
+    "Briefed", "Cast", "Rolled", "Took", "Asked", "Told", "Said", "Made",
+    "Walked", "Came", "Went", "Got", "Found", "Saw", "Knew", "Heard",
+    "Both", "And", "But", "When", "Then", "Now", "Here", "There",
+    "Bonus", "Crit", "Critical", "Combat", "Round", "Turn",
+}
+
+
+def _canonical_first_words(entries: dict) -> set[str]:
+    """Return first-name set from canonical entries (used to filter prose scan)."""
+    out: set[str] = set()
+    for e in entries.values():
+        if e.get("source", "canonical") != "canonical":
+            continue
+        parts = e["name"].split()
+        if parts:
+            out.add(parts[0])
+    return out
+
+
+def rebuild_with_prose() -> dict:
+    """Like rebuild() but also scans session-log files for likely NPCs.
+
+    Prose-found names are tagged `source: prose` to distinguish from
+    canonical npcs.md / npcs-full.md / characters/ entries (`source:
+    canonical`). When both sources surface the same name, canonical wins.
+    """
+    # Run the normal rebuild first to populate canonical entries
+    canonical_result = rebuild()
+    data = _load()
+    entries = data.get("entries", {})
+
+    # Mark all existing entries as canonical source
+    for e in entries.values():
+        e.setdefault("source", "canonical")
+
+    cd = campaigns_dir()
+    if not cd.exists():
+        return canonical_result
+
+    canonical_first_words = _canonical_first_words(entries)
+    prose_added = 0
+    for camp in sorted(cd.iterdir()):
+        if not camp.is_dir() or camp.name.startswith(".") or ".backup-" in camp.name:
+            continue
+        sess = _campaign_session_count(camp)
+        for cand in _scan_prose(camp, canonical_first_words):
+            s = slug(cand)
+            if not s:
+                continue
+            if s in entries:
+                # Already canonical — record additional active-in but don't downgrade
+                if camp.name not in entries[s].get("currently_active_in", []):
+                    entries[s].setdefault("currently_active_in", []).append(camp.name)
+                continue
+            # New prose-only entry
+            entries[s] = {
+                "name": cand,
+                "slug": s,
+                "type": "npc",
+                "first_campaign": camp.name,
+                "first_session": sess,
+                "first_used": _today(),
+                "currently_active_in": [camp.name],
+                "retired_from": [],
+                "source": "prose",
+            }
+            prose_added += 1
+
+    data["entries"] = entries
+    _save(data)
+    return {"campaigns": canonical_result["campaigns"],
+            "entries": len(entries),
+            "prose_added": prose_added}
+
+
 # ── CLI ───────────────────────────────────────────────────────────────────
 
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
     sub = p.add_subparsers(dest="cmd", required=True)
 
-    sub.add_parser("rebuild", help="scan all campaigns, populate registry")
+    pb = sub.add_parser("rebuild", help="scan all campaigns, populate registry")
+    pb.add_argument("--include-prose", action="store_true",
+                    help="also scan session-log.md / session-log-archive.md "
+                         "for capitalized name-like sequences (tagged "
+                         "source:prose to distinguish from canonical entries)")
 
     pl = sub.add_parser("list", help="list registry entries")
     pl.add_argument("--campaign", help="filter to this campaign's active set")
     pl.add_argument("--type", choices=["npc", "pc"], help="filter by type")
+    pl.add_argument("--source", choices=["canonical", "prose"],
+                    help="filter by source (canonical = npcs.md/characters/, "
+                         "prose = session-log mentions)")
 
     pk = sub.add_parser("lookup", help="case-insensitive lookup by name")
     pk.add_argument("name")
+
+    pc = sub.add_parser("check",
+                        help="check if a proposed name collides with the registry; "
+                             "exit 0 if unique, 1 if duplicate")
+    pc.add_argument("name")
+    pc.add_argument("--json", action="store_true",
+                    help="emit JSON instead of human text")
 
     pa = sub.add_parser("add", help="record a new name")
     pa.add_argument("--name", required=True)
@@ -298,17 +525,26 @@ def main() -> int:
     args = p.parse_args()
 
     if args.cmd == "rebuild":
-        result = rebuild()
-        print(f"name_registry: scanned {result['campaigns']} campaigns; "
-              f"{result['entries']} unique names recorded")
+        if args.include_prose:
+            result = rebuild_with_prose()
+            print(f"name_registry: scanned {result['campaigns']} campaigns; "
+                  f"{result['entries']} unique names recorded "
+                  f"({result['prose_added']} added from session-log prose scan)")
+        else:
+            result = rebuild()
+            print(f"name_registry: scanned {result['campaigns']} campaigns; "
+                  f"{result['entries']} unique names recorded")
         print(f"  registry: {_registry_path()}")
         return 0
 
     if args.cmd == "list":
-        entries = list_entries(campaign=args.campaign, ntype=args.type)
+        entries = list_entries(campaign=args.campaign, ntype=args.type,
+                               source=args.source)
         for e in entries:
             active = ",".join(e.get("currently_active_in", [])) or "(retired everywhere)"
-            print(f"  {e['type']:3s}  {e['name']:30s}  first: {e['first_campaign']} S{e['first_session']}  active: {active}")
+            src = e.get("source", "canonical")
+            src_marker = "" if src == "canonical" else f" [{src}]"
+            print(f"  {e['type']:3s}  {e['name']:30s}  first: {e['first_campaign']} S{e['first_session']}  active: {active}{src_marker}")
         print(f"\n  total: {len(entries)} entries")
         return 0
 
@@ -319,6 +555,18 @@ def main() -> int:
             return 1
         print(json.dumps(e, indent=2, ensure_ascii=False))
         return 0
+
+    if args.cmd == "check":
+        result = check(args.name)
+        if args.json:
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+        else:
+            if result["is_duplicate"]:
+                marker = "WARN" if result["severity"] == "warn" else "STRICT"
+                print(f"  [{marker}] DUPLICATE — {result['message']}")
+            else:
+                print(f"  [OK] {result['message']}")
+        return 1 if result["is_duplicate"] else 0
 
     if args.cmd == "add":
         e = add(args.name, args.type, args.campaign, args.session)

--- a/scripts/npc_rename.py
+++ b/scripts/npc_rename.py
@@ -92,8 +92,54 @@ def random_name(taken_slugs: set[str]) -> str:
 # ── File-set discovery ────────────────────────────────────────────────────
 
 _TEXT_FILES_ALWAYS = ["npcs.md", "npcs-full.md", "state.md",
-                      "session-log.md", "world.md"]
+                      "session-log.md", "world.md",
+                      "session_tail.json"]  # display companion's last-N events
 _TEXT_FILES_OPTIONAL = ["session-log-archive.md"]
+
+# Honorific prefixes to strip when computing title-stripped variants.
+# When renaming "Brother Calshen Drey" we ALSO want to match bare
+# "Calshen Drey" references in the same files. Only strips when the
+# remaining tail is ≥ 2 words and ≥ 6 characters (avoids "Brother John"
+# stripping to ambiguous "John").
+_HONORIFICS = {
+    "brother", "sister", "father", "mother", "lord", "lady", "sir", "dame",
+    "captain", "master", "mistress", "miss", "mr", "mr.", "mrs", "mrs.",
+    "ms", "ms.", "dr", "dr.", "king", "queen", "prince", "princess",
+    "duke", "duchess", "count", "countess", "baron", "baroness", "doctor",
+    "professor", "elder", "abbot", "abbess",
+}
+
+
+def _title_stripped(name: str) -> str | None:
+    """Return the name without leading honorific, or None if not eligible.
+
+    Only returns a stripped form when:
+      - first word is in _HONORIFICS
+      - remaining tail has ≥ 2 words AND ≥ 6 characters total
+    """
+    parts = name.strip().split()
+    if len(parts) < 3:
+        return None
+    if parts[0].lower().rstrip(".") not in _HONORIFICS:
+        return None
+    tail = " ".join(parts[1:])
+    if len(tail) < 6:
+        return None
+    return tail
+
+
+def _name_variants(name: str) -> list[str]:
+    """Return all variants of a name to search/replace.
+
+    First the full name, then the title-stripped form if eligible.
+    Order matters — the full form must be replaced first so the stripped
+    form doesn't accidentally swap inside the already-replaced text.
+    """
+    variants = [name]
+    stripped = _title_stripped(name)
+    if stripped:
+        variants.append(stripped)
+    return variants
 
 
 def _files_to_scan(camp_dir: pathlib.Path,
@@ -127,8 +173,14 @@ def _whole_word_pattern(name: str) -> re.Pattern:
 
 def find_hits(camp_dir: pathlib.Path, old: str,
               include_archive: bool) -> dict[pathlib.Path, list[tuple[int, str]]]:
-    """Scan all relevant files; return {file: [(line_num, line), ...]}."""
-    pat = _whole_word_pattern(old)
+    """Scan all relevant files; return {file: [(line_num, line), ...]}.
+
+    Searches both the full name AND the title-stripped variant (e.g.
+    'Calshen Drey' for 'Brother Calshen Drey'). Each hit line is reported
+    once even if both variants match it.
+    """
+    variants = _name_variants(old)
+    patterns = [_whole_word_pattern(v) for v in variants]
     hits: dict[pathlib.Path, list[tuple[int, str]]] = {}
     for f in _files_to_scan(camp_dir, include_archive):
         try:
@@ -136,9 +188,11 @@ def find_hits(camp_dir: pathlib.Path, old: str,
         except OSError:
             continue
         matches: list[tuple[int, str]] = []
+        seen_lines: set[int] = set()
         for n, line in enumerate(text.splitlines(), start=1):
-            if pat.search(line):
+            if any(p.search(line) for p in patterns) and n not in seen_lines:
                 matches.append((n, line.rstrip()))
+                seen_lines.add(n)
         if matches:
             hits[f] = matches
     return hits
@@ -147,13 +201,35 @@ def find_hits(camp_dir: pathlib.Path, old: str,
 # ── Apply ─────────────────────────────────────────────────────────────────
 
 def apply_text_rename(path: pathlib.Path, old: str, new: str) -> int:
-    """Whole-word replace old → new in path. Returns replacement count."""
-    pat = _whole_word_pattern(old)
+    """Replace each variant of `old` with the corresponding variant of `new`.
+
+    Variant pairing:
+      - full(old) → full(new)
+      - stripped(old) → stripped(new) if stripped(new) exists, else full(new)
+
+    Order: full first (longest match wins), then stripped — so we don't
+    accidentally double-replace inside an already-substituted string.
+    Returns total replacement count across all variants.
+    """
     text = path.read_text(errors="replace")
-    new_text, n = pat.subn(new, text)
-    if n > 0:
-        path.write_text(new_text)
-    return n
+    total = 0
+
+    old_full = old
+    new_full = new
+    pat_full = _whole_word_pattern(old_full)
+    text, n = pat_full.subn(new_full, text)
+    total += n
+
+    old_stripped = _title_stripped(old)
+    if old_stripped:
+        new_stripped = _title_stripped(new) or new_full
+        pat_stripped = _whole_word_pattern(old_stripped)
+        text, n = pat_stripped.subn(new_stripped, text)
+        total += n
+
+    if total > 0:
+        path.write_text(text)
+    return total
 
 
 def apply_graph_rename(graph_path: pathlib.Path, old: str, new: str) -> bool:


### PR DESCRIPTION
Builds on PR #26. Adds Piece 2 (creation-time uniqueness check) + opt-in prose scan + two npc_rename script-hardening fixes surfaced by smoke testing.

**name_registry.py:**
- New `check NAME [--json]` subcommand. Exit 0 unique / 1 duplicate. Severity (warn|strict|none) configurable via `.name_registry_config.json`. Wired into /dnd new + /dnd character new + /dnd npc <new> procedures.
- New `rebuild --include-prose` opt-in flag. Scans session-log for capitalized 2–3 word sequences. Filtered against stopwords + PC-name + D&D-mechanic patterns + digit-suffix outcomes. Tagged `source: prose`. **Honest caveat documented:** regex extraction is noisy (~10–20% real catches); LLM-backed extraction is the future quality move.
- New `--source canonical|prose` filter on `list`.

**npc_rename.py:**
- Added `session_tail.json` to scan list (fixes display-replay leak observed during Brother Calshen Drey rename).
- Title-stripped variant matching: when renaming "Brother Calshen Drey", also matches bare "Calshen Drey" references. Stripping triggers only for honorific prefixes (Brother/Sister/Father/Mother/Lord/Lady/Sir/Dame/etc.) AND when remaining tail is ≥ 2 words and ≥ 6 characters.

**SKILL-commands.md:** procedure hooks for /dnd new + /dnd character new + /dnd npc <new>; expanded /dnd registry docs.

Smoke-tested live against mom-dad-campaign-0 (13 campaigns, 67 canonical names): check passes both sides, rename re-run cleared 0 stragglers.