### PR TITLE
feat(display): phone dice companion + DM-driven prescribed rolls

### DIFF
--- a/display/dnd-display-app.py
+++ b/display/dnd-display-app.py
@@ -1040,6 +1040,20 @@ _load_stats()
 _input_queue: list[dict] = []
 _input_lock = threading.Lock()
 
+# Pending DM-issued dice requests: request_id → {chars: set[str], meta: {...}, started_at: float}
+# A request is "complete" when its chars set is empty (every prescribed player rolled).
+# send.py --wait polls GET /dice-request/<id> to know when the DM can move on.
+_dice_pending: dict = {}
+_dice_pending_lock = threading.Lock()
+
+
+def _dice_pending_snapshot() -> list:
+    with _dice_pending_lock:
+        return [
+            {"request_id": rid, "pending": sorted(e["chars"]), "label": e["meta"].get("label", "")}
+            for rid, e in _dice_pending.items() if e["chars"]
+        ]
+
 
 def _load_input_queue() -> None:
     global _input_queue
@@ -1902,6 +1916,267 @@ def player_input():
     return "", 204
 
 
+@app.route("/player-input/dice", methods=["POST"])
+def player_dice():
+    """Server-side dice roll submitted from a player's phone.
+
+    Body: {"character": "Piper", "spec": "1d20", "modifier": 5,
+           "advantage": "normal" | "advantage" | "disadvantage",
+           "label": "Stealth check"  (optional)}
+
+    Rolls server-side (secrets.randbelow → uniform, non-spoofable), broadcasts
+    a dice-typed entry on the feed, and returns the result so the phone can
+    finish its slot-machine animation on the real value.
+    """
+    if not _token_ok():
+        return "Forbidden", 403
+
+    data = request.get_json(force=True, silent=True) or {}
+    character = re.sub(r"[`\\$]", "", str(data.get("character", "Player"))[:50]).strip() or "Player"
+    spec      = str(data.get("spec", "1d20")).strip().lower()
+    modifier  = int(data.get("modifier", 0) or 0)
+    adv       = str(data.get("advantage", "normal")).strip().lower()
+    label     = re.sub(r"[`\\$]", "", str(data.get("label", ""))[:60]).strip()
+    req_id    = str(data.get("request_id", "")).strip()[:24]
+
+    m = re.fullmatch(r"(\d{1,2})d(\d{1,3})", spec)
+    if not m:
+        return jsonify({"error": "bad spec"}), 400
+    n_dice, n_sides = int(m.group(1)), int(m.group(2))
+    if not (1 <= n_dice <= 20 and 2 <= n_sides <= 100):
+        return jsonify({"error": "out of range"}), 400
+    modifier = max(-100, min(100, modifier))
+
+    def _roll_once() -> list[int]:
+        return [secrets.randbelow(n_sides) + 1 for _ in range(n_dice)]
+
+    if adv in ("advantage", "disadvantage") and spec == "1d20":
+        r1, r2 = _roll_once(), _roll_once()
+        chosen = max(r1[0], r2[0]) if adv == "advantage" else min(r1[0], r2[0])
+        rolls  = [chosen]
+        kept   = [chosen]
+        both   = [r1[0], r2[0]]
+    else:
+        rolls = _roll_once()
+        kept  = rolls
+        both  = None
+
+    subtotal = sum(kept)
+    total    = subtotal + modifier
+    mod_str  = (f"+{modifier}" if modifier > 0 else (str(modifier) if modifier < 0 else ""))
+    breakdown = f"[{', '.join(str(r) for r in (both or rolls))}]"
+    if both is not None:
+        breakdown += f" → keep {kept[0]} ({adv})"
+    if modifier:
+        breakdown += f" {mod_str}"
+    suffix = f" — {label}" if label else ""
+    text   = f"{character} rolls {spec}{mod_str}: {breakdown} = {total}{suffix}"
+
+    payload   = {"text": text, "dice": True}
+    log_entry = {"text": text, "dice": True}
+    try:
+        _camp_stamp = open(CAMP_FILE).read().strip()
+        if _camp_stamp:
+            log_entry["_camp"] = _camp_stamp
+    except Exception:
+        pass
+
+    with _text_log_lock:
+        _text_log.append(log_entry)
+    with _tail_lock:
+        _tail_buffer.append(log_entry)
+    _persist_log()
+    _persist_tail()
+    _broadcast(payload)
+
+    # Correlate against any pending DM request. Case-insensitive match on the
+    # character name — drop them from the request's expected-rollers set.
+    pending_changed = False
+    if req_id:
+        with _dice_pending_lock:
+            entry = _dice_pending.get(req_id)
+            if entry is not None:
+                ci = character.lower()
+                matched = next((c for c in entry["chars"] if c.lower() == ci), None)
+                if matched is not None:
+                    entry["chars"].discard(matched)
+                    pending_changed = True
+                    if not entry["chars"]:
+                        _dice_pending.pop(req_id, None)
+    if pending_changed:
+        _broadcast({"dice_pending": _dice_pending_snapshot()})
+
+    return jsonify({
+        "character": character,
+        "spec": spec,
+        "modifier": modifier,
+        "advantage": adv,
+        "rolls": rolls,
+        "kept": kept,
+        "both": both,
+        "subtotal": subtotal,
+        "total": total,
+        "text": text,
+        "request_id": req_id or None,
+    }), 200
+
+
+@app.route("/dice-request", methods=["POST"])
+def dice_request():
+    """DM-initiated dice request — broadcast to player phones (no persistence).
+
+    Body: {"character": "Piper" | "any",
+           "spec": "1d20", "modifier": 5,
+           "advantage": "normal" | "advantage" | "disadvantage",
+           "label": "Stealth check"  (optional),
+           "dc": 15  (optional, informational)}
+
+    Phones bound to ?character=<name> match case-insensitively. "any" / ""
+    targets every phone. No state stored — late-joining phones will not see
+    requests issued before they connected.
+    """
+    if not _token_ok():
+        return "Forbidden", 403
+
+    import time
+    data = request.get_json(force=True, silent=True) or {}
+    raw_char  = data.get("characters") if "characters" in data else data.get("character", "any")
+    if isinstance(raw_char, list):
+        chars = [str(c).strip() for c in raw_char if str(c).strip()]
+    else:
+        chars = [c.strip() for c in re.sub(r"[`\\$]", "", str(raw_char))[:200].split(",") if c.strip()]
+    if not chars:
+        chars = ["any"]
+
+    spec      = str(data.get("spec", "1d20")).strip().lower()
+    modifier  = int(data.get("modifier", 0) or 0)
+    adv       = str(data.get("advantage", "normal")).strip().lower()
+    label     = re.sub(r"[`\\$]", "", str(data.get("label", ""))[:60]).strip()
+    dc        = data.get("dc")
+
+    if not re.fullmatch(r"\d{1,2}d\d{1,3}", spec):
+        return jsonify({"error": "bad spec"}), 400
+    if adv not in ("normal", "advantage", "disadvantage"):
+        adv = "normal"
+    modifier = max(-100, min(100, modifier))
+    dc_val   = int(dc) if isinstance(dc, (int, float)) else None
+
+    request_id = secrets.token_hex(6)
+
+    # Only register pending entries for explicit named targets. "any" is fire-and-forget.
+    trackable = [c for c in chars if c.lower() != "any"]
+    if trackable:
+        with _dice_pending_lock:
+            _dice_pending[request_id] = {
+                "chars": set(trackable),
+                "meta": {"spec": spec, "modifier": modifier, "advantage": adv, "label": label, "dc": dc_val},
+                "started_at": time.time(),
+            }
+        _broadcast({"dice_pending": _dice_pending_snapshot()})
+
+    payload = {
+        "dice_request": {
+            "request_id": request_id,
+            "characters": chars,
+            "character": chars[0] if len(chars) == 1 else "any",   # legacy single-target field
+            "spec": spec,
+            "modifier": modifier,
+            "advantage": adv,
+            "label": label,
+            "dc": dc_val,
+        }
+    }
+    _broadcast(payload)
+    return jsonify({
+        "request_id": request_id,
+        "pending": sorted(trackable),
+        "complete": not trackable,
+    }), 200
+
+
+@app.route("/dice-request/<request_id>", methods=["GET"])
+def dice_request_status(request_id):
+    """Poll a dice request's completion state.
+
+    Returns 200 with {complete, pending, label, started_at}. A request that
+    never existed (or has already fully drained) reports complete=True with
+    an empty pending list — send.py --wait treats both identically.
+    """
+    if not _token_ok():
+        return "Forbidden", 403
+    with _dice_pending_lock:
+        entry = _dice_pending.get(request_id)
+        if entry is None or not entry["chars"]:
+            return jsonify({"complete": True, "pending": []}), 200
+        return jsonify({
+            "complete": False,
+            "pending": sorted(entry["chars"]),
+            "label": entry["meta"].get("label", ""),
+            "started_at": entry["started_at"],
+        }), 200
+
+
+@app.route("/dice-request/<request_id>", methods=["DELETE"])
+def dice_request_cancel(request_id):
+    """Cancel a pending dice request (DM gave up waiting / moved on)."""
+    if not _token_ok():
+        return "Forbidden", 403
+    with _dice_pending_lock:
+        _dice_pending.pop(request_id, None)
+    _broadcast({"dice_pending": _dice_pending_snapshot(), "dice_request_cancelled": request_id})
+    return "", 204
+
+
+@app.route("/character/<character>", methods=["GET"])
+def get_character_sheet(character):
+    """Return the markdown content of a PC sheet for the active campaign.
+
+    Used by the phone's Character tab. Resolves the active campaign from
+    CAMP_FILE, then reads:
+        <DND_CAMPAIGN_ROOT>/campaigns/<campaign>/characters/<character>.md
+
+    Falls back to the global roster at ~/.claude/dnd/characters/<character>.md
+    if the campaign-side file is missing — useful when the character was just
+    imported but not yet replicated.
+
+    Returns text/markdown so the phone can render in JS without server-side
+    dependencies (no `markdown` lib required).
+    """
+    if not _token_ok():
+        return "Forbidden", 403
+
+    safe = re.sub(r"[^A-Za-z0-9 _-]", "", character).strip()[:50]
+    if not safe:
+        return "Bad character name", 400
+
+    try:
+        camp = open(CAMP_FILE).read().strip()
+    except Exception:
+        camp = ""
+    # Sanitise the campaign name with the same allowlist + length cap as the
+    # character argument. CAMP_FILE is writable by anyone inside the LAN+token
+    # trust boundary (via push_stats.py --set-campaign), so a malicious value
+    # here could pivot to arbitrary `<name>.md` reads via os.path.join.
+    camp = re.sub(r"[^A-Za-z0-9_-]", "", camp)[:50]
+
+    root = os.environ.get("DND_CAMPAIGN_ROOT", os.path.expanduser("~/.claude/dnd"))
+    candidates = []
+    if camp:
+        candidates.append(os.path.join(root, "campaigns", camp, "characters", f"{safe}.md"))
+    candidates.append(os.path.expanduser(f"~/.claude/dnd/characters/{safe}.md"))
+
+    for path in candidates:
+        if os.path.isfile(path):
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    body = f.read()
+            except Exception as e:
+                return f"Read error: {e}", 500
+            return Response(body, mimetype="text/markdown; charset=utf-8")
+
+    return f"No sheet found for '{safe}' in campaign '{camp}'", 404
+
+
 @app.route("/device/approve", methods=["POST"])
 def device_approve():
     """DM approves a pending device. Body: {"id": "<device_id>"}"""
@@ -2176,6 +2451,29 @@ def stream():
     with _queue_status_lock:
         if _queue_status:
             q.put_nowait({"queue_status": list(_queue_status)})
+
+    # Send current pending dice requests so the "Waiting on…" badge survives reload.
+    snap = _dice_pending_snapshot()
+    if snap:
+        q.put_nowait({"dice_pending": snap})
+
+    # Replay every active dice_request so phones that connected *after* a DM
+    # broadcast still pre-fill their pad and store the request_id. Without this,
+    # a late-joining or reloaded phone rolls without a request_id, the roll logs
+    # but the pending set never drains, and the "Waiting on…" banner gets stuck.
+    with _dice_pending_lock:
+        active = [(rid, dict(e["meta"]), sorted(e["chars"])) for rid, e in _dice_pending.items() if e["chars"]]
+    for rid, meta, chars in active:
+        q.put_nowait({"dice_request": {
+            "request_id": rid,
+            "characters": chars,
+            "character": chars[0] if len(chars) == 1 else "any",
+            "spec": meta.get("spec", "1d20"),
+            "modifier": meta.get("modifier", 0),
+            "advantage": meta.get("advantage", "normal"),
+            "label": meta.get("label", ""),
+            "dc": meta.get("dc"),
+        }})
 
     # Replay autorun cycle so reconnecting clients resume the countdown from correct elapsed position.
     with _autorun_cycle_lock:

--- a/display/send.py
+++ b/display/send.py
@@ -70,6 +70,7 @@ BASE_URL    = f"{_SCHEME}://localhost:5001"
 FLASK_URL   = f"{BASE_URL}/chunk"
 STATS_URL   = f"{BASE_URL}/stats"
 HEALTH_URL  = f"{BASE_URL}/health"
+DICE_REQ_URL = f"{BASE_URL}/dice-request"
 TOKEN_FILE  = os.path.expanduser("~/.claude/skills/dnd/display/.token")
 TIMEOUT     = 8.0
 RETRIES     = 1                # one retry on timeout/connection error
@@ -405,6 +406,30 @@ def main() -> None:
     parser.add_argument("--xp-award", metavar="JSON",
         help='XP award block: \'{"names":["Aldric","Mira"],"xp":250,"reason":"Encounter resolved","total":"3250/6500"}\'')
 
+    # ── Dice request (DM → player phones) ────────────────────────────────────
+    parser.add_argument("--dice-request", action="store_true",
+        help='Broadcast a dice request to player phones (pre-fills their pad). '
+             'Combine with --character / --spec / --modifier / --advantage / --label / --dc.')
+    parser.add_argument("--character", metavar="NAME",
+        help='Target character for --dice-request. Use "any" or omit to target every phone.')
+    parser.add_argument("--spec", metavar="NdM", default="1d20",
+        help='Dice spec for --dice-request (default 1d20). Examples: 1d20, 2d6, 1d100.')
+    parser.add_argument("--modifier", type=int, default=0, metavar="N",
+        help='Modifier to apply on the phone (default 0). May be negative.')
+    parser.add_argument("--advantage", choices=["normal", "advantage", "disadvantage"],
+        default="normal",
+        help='For 1d20 only: normal | advantage | disadvantage (default normal).')
+    parser.add_argument("--label", metavar="TEXT",
+        help='Human label for the roll (e.g. "Stealth check", "Concentration save").')
+    parser.add_argument("--dc", type=int, metavar="N",
+        help='Optional DC; displayed informationally on the phone.')
+    parser.add_argument("--wait", action="store_true",
+        help='With --dice-request: block until every prescribed character has rolled '
+             '(polls /dice-request/<id>). Exits non-zero on timeout.')
+    parser.add_argument("--wait-timeout", type=int, default=120, metavar="SECONDS",
+        help='Timeout for --wait (default 120s). On timeout, prints still-pending '
+             'characters to stderr and exits 2.')
+
     # ── Stat-change flags (Option B — bundled with narration) ─────────────────
     parser.add_argument("--stat-hp", action="append", metavar="NAME:CUR:MAX",
         help="Set HP: NAME:CURRENT:MAX (can repeat for multiple players)")
@@ -447,6 +472,83 @@ def main() -> None:
     # which silently dropped any heredoc body bundled with them. Reading piped
     # stdin under the same isatty() gate as stat flags lets bundled narration
     # flow through to the text-send block below.
+    # ── Dice request (DM → phones) — broadcast + optional blocking wait ──────
+    if args.dice_request:
+        # Comma-split character list so the DM can address multiple players at once,
+        # e.g. --character "Piper,Mira,Aldric"  → all three must roll before --wait returns.
+        chars = [c.strip() for c in (args.character or "any").split(",") if c.strip()] or ["any"]
+        body = {
+            "characters": chars,
+            "spec": args.spec,
+            "modifier": args.modifier,
+            "advantage": args.advantage,
+        }
+        if args.label: body["label"] = args.label
+        if args.dc is not None: body["dc"] = args.dc
+        _token = _read_token()
+
+        # Direct urllib call (rather than _post) because we need the JSON response body.
+        headers = {"Content-Type": "application/json"}
+        if _token: headers["X-DND-Token"] = _token
+        try:
+            req = urllib.request.Request(
+                DICE_REQ_URL, data=json.dumps(body).encode(),
+                headers=headers, method="POST",
+            )
+            resp = urllib.request.urlopen(req, timeout=TIMEOUT, context=_SSL_CTX)
+            resp_body = json.loads(resp.read().decode("utf-8") or "{}")
+        except Exception as e:
+            print(f"send.py: dice-request failed: {e}", file=sys.stderr)
+            sys.exit(1)
+
+        request_id = resp_body.get("request_id", "")
+        pending    = list(resp_body.get("pending") or [])
+        # Machine-readable on stdout so callers can correlate (cancel, log, etc.).
+        # flush=True because Python block-buffers stdout when redirected, and
+        # callers want the id immediately to dispatch rolls / cancellation.
+        print(request_id, flush=True)
+
+        if args.wait:
+            if not pending:
+                # "any" targets aren't tracked, so --wait is a no-op there.
+                print(f"send.py: --wait with no trackable characters (target={chars}) — nothing to wait for.",
+                      file=sys.stderr)
+            else:
+                status_url = f"{DICE_REQ_URL}/{request_id}"
+                poll_headers = {"X-DND-Token": _token} if _token else {}
+                deadline = time.time() + max(1, args.wait_timeout)
+                last_pending: list = list(pending)
+                print(f"send.py: waiting for rolls from: {', '.join(pending)}", file=sys.stderr)
+                while time.time() < deadline:
+                    try:
+                        sreq = urllib.request.Request(status_url, headers=poll_headers, method="GET")
+                        s = urllib.request.urlopen(sreq, timeout=TIMEOUT, context=_SSL_CTX)
+                        st = json.loads(s.read().decode("utf-8") or "{}")
+                    except Exception as e:
+                        print(f"send.py: poll error ({e}) — retrying", file=sys.stderr)
+                        time.sleep(1.0)
+                        continue
+                    if st.get("complete"):
+                        print(f"send.py: all rolls received.", file=sys.stderr)
+                        break
+                    remaining = st.get("pending") or []
+                    if remaining != last_pending:
+                        print(f"send.py: still waiting on: {', '.join(remaining)}", file=sys.stderr)
+                        last_pending = list(remaining)
+                    time.sleep(0.5)
+                else:
+                    print(f"send.py: timeout after {args.wait_timeout}s — still pending: "
+                          f"{', '.join(last_pending)}", file=sys.stderr)
+                    sys.exit(2)
+
+        # If no other action requested, exit clean (don't fall through to stdin read).
+        _other = (args.player or args.npc or args.dice or args.tutor or args.action
+                  or args.inspiration_award or args.inspiration_spend
+                  or args.milestone_award or args.milestone_spend or args.xp_award
+                  or args.verify)
+        if not _other:
+            return
+
     _has_content_flag = bool(args.player or args.npc or args.dice or args.tutor or args.action)
     if _has_content_flag:
         text = sys.stdin.read()

--- a/display/templates/index.html
+++ b/display/templates/index.html
@@ -2,7 +2,9 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <meta name="dnd-token" content="{{ lan_token }}">
 <meta name="narrator-voice" content="{{ narrator_voice }}">
 <meta name="tts-available" content="{{ '1' if tts_available else '0' }}">
@@ -1743,6 +1745,468 @@
     vertical-align: middle;
     margin-right: 8px;
   }
+
+  /* ── Input-only view (mobile players): http://...:5001/?view=input ── */
+  body.input-only #text-scroll,
+  body.input-only #sidebar,
+  body.input-only #sidebar-toggle,
+  body.input-only #world-clock,
+  body.input-only #ruleset-badge,
+  body.input-only #audio-controls,
+  body.input-only #corner-logo,
+  body.input-only #scene-indicator,
+  body.input-only #vignette,
+  body.input-only #frame,
+  body.input-only #bottom-fade,
+  body.input-only #bg-a,
+  body.input-only #bg-b,
+  body.input-only #flash-overlay {
+    display: none !important;
+  }
+  body.input-only {
+    background: #0a0a0c !important;
+  }
+  body.input-only {
+    /* iOS Safari URL bar friendly + safe-area aware */
+    overscroll-behavior: contain;
+    -webkit-text-size-adjust: 100%;
+  }
+  body.input-only #input-panel {
+    position: fixed !important;
+    inset: 0 !important;
+    width: 100vw !important;
+    height: 100vh !important;          /* fallback */
+    height: 100dvh !important;          /* dynamic viewport (iOS 16+) */
+    max-height: 100dvh !important;
+    border-radius: 0 !important;
+    border: none !important;
+    transform: none !important;
+    padding:
+      env(safe-area-inset-top)
+      env(safe-area-inset-right)
+      env(safe-area-inset-bottom)
+      env(safe-area-inset-left) !important;
+    box-sizing: border-box !important;
+    display: flex !important;
+    flex-direction: column !important;
+  }
+  body.input-only #input-panel.collapsed {
+    transform: none !important;
+  }
+  body.input-only #input-body {
+    display: flex !important;
+    flex: 1 1 auto;
+    max-height: none !important;
+    overflow-y: auto !important;
+    -webkit-overflow-scrolling: touch;
+  }
+  /* Hide the legacy "Party Input ▲" panel header in input-only mode — the tabs
+     are now the top navigation, so the old toggle no longer serves a purpose. */
+  body.input-only #input-panel-header { display: none !important; }
+
+  /* Tab bar — only shown in input-only mode, hidden on the TV view. */
+  #dp-tabs { display: none; }
+  body.input-only #dp-tabs {
+    display: flex !important;
+    flex: 0 0 auto;
+    gap: 0;
+    border-bottom: 1px solid rgba(180,140,60,0.25);
+    background: rgba(0,0,0,0.4);
+  }
+  body.input-only .dp-tab {
+    flex: 1 1 0;
+    background: transparent;
+    color: #b8a26a;
+    border: none;
+    border-bottom: 2px solid transparent;
+    font: 700 16px/1 ui-monospace, monospace;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 16px 8px;
+    min-height: 48px;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+    transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
+  }
+  body.input-only .dp-tab.active {
+    color: #f4e2a8;
+    border-bottom-color: rgba(220,180,90,0.85);
+    background: rgba(180,140,60,0.08);
+  }
+  body.input-only .dp-tab:active { background: rgba(180,140,60,0.18); }
+
+  /* Section visibility: only the section whose data-tab-section matches
+     #input-body[data-active-tab] is shown. Every other tagged section is
+     hidden. Untagged children stay visible (none currently). */
+  body.input-only #input-body[data-active-tab="move"]      [data-tab-section="roll"],
+  body.input-only #input-body[data-active-tab="move"]      [data-tab-section="character"],
+  body.input-only #input-body[data-active-tab="roll"]      [data-tab-section="move"],
+  body.input-only #input-body[data-active-tab="roll"]      [data-tab-section="character"],
+  body.input-only #input-body[data-active-tab="character"] [data-tab-section="move"],
+  body.input-only #input-body[data-active-tab="character"] [data-tab-section="roll"] {
+    display: none !important;
+  }
+
+  /* Move tab: let the action textarea actually use the screen. */
+  body.input-only #input-body[data-active-tab="move"] #player-input-text {
+    flex: 1 1 auto;
+    min-height: 160px;
+    font-size: 16px !important;
+    padding: 14px;
+    margin: 10px 12px;
+    border-radius: 10px;
+  }
+  body.input-only #input-body[data-active-tab="move"] #input-footer {
+    padding: 0 12px 12px;
+  }
+  body.input-only #input-body[data-active-tab="move"] #stage-btn {
+    min-height: 48px;
+    padding: 14px 18px;
+    font-size: 16px;
+  }
+  /* Character pane — phone-side read-only sheet viewer. */
+  #character-pane { display: none; }
+  body.input-only #character-pane {
+    display: flex !important;
+    flex-direction: column;
+    flex: 1 1 auto;
+    padding: 12px 14px 24px;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    color: #d8c694;
+    font: 400 14px/1.5 ui-monospace, monospace;
+  }
+  body.input-only #cp-status {
+    color: rgba(180,140,60,0.5);
+    font-style: italic;
+    text-align: center;
+    padding: 8px 0;
+  }
+  body.input-only #cp-body { width: 100%; }
+  body.input-only #cp-body h1 {
+    color: #f4e2a8;
+    font: 800 22px/1.2 ui-monospace, monospace;
+    margin: 0 0 6px;
+    border-bottom: 1px solid rgba(180,140,60,0.35);
+    padding-bottom: 6px;
+  }
+  body.input-only #cp-body h2 {
+    color: #ffd98a;
+    font: 700 17px/1.3 ui-monospace, monospace;
+    margin: 20px 0 6px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+  body.input-only #cp-body h3 {
+    color: #d8c694;
+    font: 700 15px/1.3 ui-monospace, monospace;
+    margin: 14px 0 4px;
+  }
+  body.input-only #cp-body p {
+    margin: 4px 0 10px;
+    color: #c2b48a;
+  }
+  body.input-only #cp-body strong { color: #f4e2a8; font-weight: 700; }
+  body.input-only #cp-body em     { color: #b8a26a; font-style: italic; }
+  body.input-only #cp-body ul {
+    list-style: none;
+    padding-left: 0;
+    margin: 4px 0 10px;
+  }
+  body.input-only #cp-body li {
+    padding: 3px 0 3px 14px;
+    position: relative;
+  }
+  body.input-only #cp-body li::before {
+    content: '•';
+    color: rgba(180,140,60,0.7);
+    position: absolute;
+    left: 2px;
+    top: 3px;
+  }
+  body.input-only #cp-body table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 6px 0 14px;
+    font-size: 13px;
+  }
+  body.input-only #cp-body th,
+  body.input-only #cp-body td {
+    border: 1px solid rgba(180,140,60,0.25);
+    padding: 6px 8px;
+    text-align: left;
+    color: #c2b48a;
+  }
+  body.input-only #cp-body th {
+    background: rgba(180,140,60,0.12);
+    color: #f4e2a8;
+    font-weight: 700;
+  }
+  body.input-only #cp-body tr:nth-child(even) td { background: rgba(255,255,255,0.02); }
+
+  /* Notification dot on the Roll tab when an unresolved DM request targets us. */
+  body.input-only .dp-tab.has-request::after {
+    content: '';
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    margin-left: 8px;
+    border-radius: 50%;
+    background: #ffd98a;
+    box-shadow: 0 0 8px rgba(255,220,140,0.8);
+    vertical-align: middle;
+  }
+  /* iOS: prevent auto-zoom on focus by ensuring inputs are ≥16px */
+  body.input-only #player-input-text,
+  body.input-only #dp-name,
+  body.input-only #dp-label {
+    font-size: 16px !important;
+  }
+
+  /* ── Phone dice pad (visible only in input-only view) ────────────────── */
+  #dice-pad { display: none; }
+  body.input-only #dice-pad {
+    display: flex !important;
+    flex-direction: column;
+    gap: 10px;
+    padding: 12px 14px 16px;
+    border-top: 1px solid rgba(180,140,60,0.18);
+    background: rgba(0,0,0,0.35);
+  }
+  #dice-pad .dp-row {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+  }
+  #dice-pad .dp-die,
+  #dice-pad .dp-adv,
+  #dice-pad .dp-mod,
+  #dice-pad #dp-roll {
+    background: rgba(20,16,8,0.7);
+    color: #d8c694;
+    border: 1px solid rgba(180,140,60,0.35);
+    border-radius: 10px;
+    font: 600 16px/1 ui-monospace, monospace;
+    padding: 12px 14px;
+    min-width: 56px;
+    min-height: 44px;                       /* iOS HIG tap target */
+    text-align: center;
+    cursor: pointer;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;             /* kill 300 ms double-tap zoom */
+    appearance: none;
+    -webkit-appearance: none;
+    transition: transform 80ms ease, background 120ms ease;
+  }
+  #dice-pad .dp-die:active,
+  #dice-pad .dp-adv:active,
+  #dice-pad .dp-mod:active,
+  #dice-pad #dp-roll:active {
+    transform: scale(0.94);
+    background: rgba(180,140,60,0.32);
+  }
+  #dice-pad .dp-die[disabled],
+  #dice-pad .dp-adv[disabled],
+  #dice-pad .dp-mod[disabled] {
+    opacity: 0.25;
+    pointer-events: none;
+  }
+  #dice-pad #dp-label[readonly] {
+    opacity: 0.5;
+  }
+  #dp-hint {
+    text-align: center;
+    color: rgba(180,140,60,0.65);
+    font: 400 12px/1.3 ui-monospace, monospace;
+    margin-top: -4px;
+  }
+  #dice-pad .dp-die.active,
+  #dice-pad .dp-adv.active {
+    background: rgba(180,140,60,0.25);
+    border-color: rgba(220,180,90,0.8);
+    color: #f4e2a8;
+  }
+  #dice-pad .dp-mod { min-width: 38px; padding: 10px 8px; }
+  #dice-pad #dp-mod-val {
+    color: #f4e2a8;
+    font: 600 16px/1 ui-monospace, monospace;
+    min-width: 36px;
+    text-align: center;
+  }
+  #dice-pad #dp-label {
+    background: rgba(0,0,0,0.4);
+    color: #d8c694;
+    border: 1px solid rgba(180,140,60,0.25);
+    border-radius: 8px;
+    padding: 8px 10px;
+    font: 400 14px/1.2 ui-monospace, monospace;
+    width: 100%;
+    box-sizing: border-box;
+  }
+  #dice-pad #dp-label::placeholder { color: rgba(180,140,60,0.4); }
+  #dice-pad #dp-name {
+    background: rgba(0,0,0,0.4);
+    color: #f4e2a8;
+    border: 1px solid rgba(180,140,60,0.3);
+    border-radius: 8px;
+    padding: 8px 10px;
+    font: 600 14px/1 ui-monospace, monospace;
+    width: 120px;
+    text-align: center;
+  }
+  #dice-pad #dp-roll {
+    flex: 1 1 auto;
+    background: linear-gradient(180deg, rgba(180,140,60,0.45), rgba(120,80,30,0.55));
+    color: #fff8dc;
+    border-color: rgba(220,180,90,0.7);
+    font-size: 17px;
+    letter-spacing: 0.04em;
+    padding: 14px 16px;
+  }
+  #dice-pad #dp-roll:disabled { opacity: 0.5; }
+
+  /* Slot-machine reel */
+  #dp-reel-wrap {
+    height: 86px;
+    border: 1px solid rgba(180,140,60,0.4);
+    border-radius: 12px;
+    background: radial-gradient(ellipse at center, rgba(40,30,10,0.9), rgba(0,0,0,0.95));
+    overflow: hidden;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: inset 0 0 30px rgba(0,0,0,0.7);
+  }
+  #dp-reel-wrap::before,
+  #dp-reel-wrap::after {
+    content: '';
+    position: absolute;
+    left: 0; right: 0;
+    height: 22px;
+    pointer-events: none;
+    z-index: 2;
+  }
+  #dp-reel-wrap::before {
+    top: 0;
+    background: linear-gradient(180deg, rgba(0,0,0,0.95), transparent);
+  }
+  #dp-reel-wrap::after {
+    bottom: 0;
+    background: linear-gradient(0deg, rgba(0,0,0,0.95), transparent);
+  }
+  #dp-reel {
+    font: 700 44px/1 ui-monospace, monospace;
+    color: #f4e2a8;
+    text-shadow: 0 0 14px rgba(220,180,90,0.55);
+    will-change: transform;
+    transform: translateY(0);
+  }
+  #dp-reel.spinning { animation: dp-blur 80ms linear infinite; }
+  @keyframes dp-blur {
+    0%   { filter: blur(0.4px); }
+    50%  { filter: blur(1.2px); }
+    100% { filter: blur(0.4px); }
+  }
+  #dp-result-line {
+    text-align: center;
+    color: #b8a26a;
+    font: 500 13px/1.4 ui-monospace, monospace;
+    min-height: 18px;
+  }
+  #dp-result-line .total {
+    color: #f4e2a8;
+    font-weight: 700;
+    font-size: 15px;
+  }
+  #dp-reel.locked { animation: dp-lock 0.45s ease-out; }
+  @keyframes dp-lock {
+    0%   { transform: scale(1.0); }
+    35%  { transform: scale(1.18); color: #fff8dc; text-shadow: 0 0 24px rgba(255,220,140,0.9); }
+    100% { transform: scale(1.0); }
+  }
+
+  /* Main-display "Waiting on…" badge while a DM dice-request is unresolved.
+     Hidden in input-only (phone) mode so it stays a DM-side indicator only. */
+  #dice-pending-badge {
+    display: none;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 60;
+    background: rgba(20,12,4,0.92);
+    color: #f4e2a8;
+    border: 1px solid rgba(220,180,90,0.55);
+    border-radius: 12px;
+    padding: 8px 16px;
+    font: 600 14px/1.3 ui-monospace, monospace;
+    letter-spacing: 0.04em;
+    text-align: center;
+    box-shadow: 0 0 22px rgba(0,0,0,0.6), 0 0 0 0 rgba(255,220,140,0.5);
+    animation: dpb-pulse 1.6s ease-in-out infinite;
+    pointer-events: none;
+    max-width: 80vw;
+  }
+  #dice-pending-badge.visible { display: block; }
+  #dice-pending-badge .dpb-label {
+    display: block;
+    font-weight: 400;
+    font-size: 12px;
+    color: #b8a26a;
+    letter-spacing: 0.02em;
+    margin-top: 2px;
+  }
+  @keyframes dpb-pulse {
+    0%   { box-shadow: 0 0 22px rgba(0,0,0,0.6), 0 0 0 0   rgba(255,220,140,0.5); }
+    70%  { box-shadow: 0 0 22px rgba(0,0,0,0.6), 0 0 0 12px rgba(255,220,140,0); }
+    100% { box-shadow: 0 0 22px rgba(0,0,0,0.6), 0 0 0 0   rgba(255,220,140,0); }
+  }
+  body.input-only #dice-pending-badge { display: none !important; }
+
+  /* Bound character header + Roll-button pulse on DM request */
+  #dp-bound {
+    text-align: center;
+    color: #f4e2a8;
+    font: 700 13px/1.2 ui-monospace, monospace;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    opacity: 0.85;
+  }
+  #dp-bound .req {
+    display: block;
+    margin-top: 4px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    text-transform: none;
+    color: #ffd98a;
+    font-size: 13px;
+  }
+  body.input-only #dp-name.locked {
+    opacity: 0.6;
+    pointer-events: none;
+  }
+  #dp-roll.pulse {
+    animation: dp-pulse 0.9s ease-in-out infinite;
+    box-shadow: 0 0 0 0 rgba(255,220,140,0.6);
+  }
+  #dp-roll.rolled {
+    /* Visually distinct "you've already rolled — wait for the DM" state. */
+    background: rgba(20,16,8,0.6);
+    color: #8a7a4a;
+    border-color: rgba(120,90,30,0.4);
+    opacity: 0.6;
+  }
+  @keyframes dp-pulse {
+    0%   { box-shadow: 0 0 0 0   rgba(255,220,140,0.55); }
+    70%  { box-shadow: 0 0 0 14px rgba(255,220,140,0); }
+    100% { box-shadow: 0 0 0 0   rgba(255,220,140,0); }
+  }
 </style>
 </head>
 <body>
@@ -1803,6 +2267,9 @@
 <!-- Device approval cards — shown when a new LAN device requests input access -->
 <div id="device-approvals"></div>
 
+<!-- DM-side waiting badge for active dice-requests (driven by SSE dice_pending) -->
+<div id="dice-pending-badge"></div>
+
 <!-- Player input panel — submit actions from the display companion -->
 <div id="input-panel" class="collapsed">
   <div id="input-panel-header">
@@ -1818,16 +2285,70 @@
     </div>
     <span id="input-toggle-arrow">▲</span>
   </div>
-  <div id="input-body">
-    <div id="staged-queue"></div>
-    <div id="waiting-indicator"></div>
-    <div id="char-tabs">
+  <div id="input-body" data-active-tab="move">
+    <!-- Phone-only tab bar (shown by ?view=input). Top-level switcher between
+         the action input (Move) and the dice pad (Roll). The same DOM children
+         exist for the TV view too — tab data-attributes only take effect in
+         input-only mode. -->
+    <div id="dp-tabs">
+      <button class="dp-tab active" data-tab="move" type="button">Move</button>
+      <button class="dp-tab"        data-tab="roll" type="button">Roll</button>
+      <button class="dp-tab"        data-tab="character" type="button">Sheet</button>
+    </div>
+    <div id="staged-queue" data-tab-section="move"></div>
+    <div id="waiting-indicator" data-tab-section="move"></div>
+    <div id="char-tabs" data-tab-section="move">
       <button class="char-tab active" data-char="Everybody">Everybody</button>
     </div>
-    <textarea id="player-input-text" rows="2" placeholder="Enter action or dialogue…" maxlength="500"></textarea>
-    <div id="input-footer">
+    <textarea id="player-input-text" rows="2" placeholder="Enter action or dialogue…" maxlength="500"
+              data-tab-section="move"></textarea>
+    <div id="input-footer" data-tab-section="move">
       <button id="skip-turn-btn" style="display:none" title="Skip this character's turn">Skip Turn</button>
       <button id="stage-btn">Stage</button>
+    </div>
+    <!-- Phone-only dice pad (shown by ?view=input) -->
+    <div id="dice-pad" data-tab-section="roll">
+      <div id="dp-bound" style="display:none"></div>
+      <div class="dp-row">
+        <input id="dp-name" type="text" maxlength="24" placeholder="Name"
+               autocomplete="off" autocorrect="off" autocapitalize="words" spellcheck="false">
+      </div>
+      <div id="dp-reel-wrap"><div id="dp-reel">d20</div></div>
+      <div id="dp-result-line"></div>
+      <div class="dp-row" id="dp-die-row">
+        <button class="dp-die active" data-spec="1d20">d20</button>
+        <button class="dp-die" data-spec="1d4">d4</button>
+        <button class="dp-die" data-spec="1d6">d6</button>
+        <button class="dp-die" data-spec="1d8">d8</button>
+        <button class="dp-die" data-spec="1d10">d10</button>
+        <button class="dp-die" data-spec="1d12">d12</button>
+        <button class="dp-die" data-spec="1d100">d100</button>
+        <button class="dp-die" data-spec="2d6">2d6</button>
+      </div>
+      <div class="dp-row">
+        <button class="dp-adv active" data-adv="normal"  title="Roll one d20">Straight</button>
+        <button class="dp-adv"        data-adv="advantage"    title="Roll two d20s, keep higher">Adv ▲</button>
+        <button class="dp-adv"        data-adv="disadvantage" title="Roll two d20s, keep lower">Dis ▼</button>
+      </div>
+      <div id="dp-hint">Advantage / disadvantage applies only to d20 rolls.</div>
+      <div class="dp-row">
+        <button class="dp-mod" data-delta="-1" aria-label="decrease modifier">−</button>
+        <span style="opacity:.7">Mod</span>
+        <span id="dp-mod-val">+0</span>
+        <button class="dp-mod" data-delta="1" aria-label="increase modifier">+</button>
+      </div>
+      <div class="dp-row">
+        <input id="dp-label" type="text" maxlength="60" placeholder="Label (e.g. Stealth) — optional"
+               autocomplete="off" autocorrect="off" autocapitalize="sentences" spellcheck="false">
+      </div>
+      <div class="dp-row">
+        <button id="dp-roll">Roll</button>
+      </div>
+    </div>
+    <!-- Phone-only character sheet pane (Sheet tab) -->
+    <div id="character-pane" data-tab-section="character">
+      <div id="cp-status">Loading…</div>
+      <div id="cp-body"></div>
     </div>
   </div>
 </div>
@@ -2604,7 +3125,7 @@ textScroll.addEventListener('scroll', () => {
   userScrolledUp = distFromBottom > 80;
 });
 
-let charDelay = 18;      // ms per character while typing (mutable — see speed toggle)
+let charDelay = 36;      // ms per character while typing (mutable — see speed toggle)
 const IDLE_GAP   = 1800; // ms silence before starting a new block
 
 function getOrCreateBlock() {
@@ -4217,8 +4738,8 @@ document.getElementById('sfx-row').addEventListener('click', () => {
 
 // ── Typing speed toggle ──────────────────────────────────────────────
 const _speedSteps = [
-  { label: 'Normal',  ms: 18 },
-  { label: 'Fast',    ms: 7  },
+  { label: 'Normal',  ms: 36 },
+  { label: 'Fast',    ms: 18 },
   { label: 'Instant', ms: 0  },
 ];
 let _speedIdx = 0;
@@ -4995,6 +5516,16 @@ function connect() {
     let payload;
     try { payload = JSON.parse(e.data); } catch { return; }
 
+    if (payload.dice_request && typeof window._onDiceRequest === 'function') {
+      window._onDiceRequest(payload.dice_request);
+    }
+    if (payload.dice_request_cancelled && typeof window._onDiceRequestCancelled === 'function') {
+      window._onDiceRequestCancelled(payload.dice_request_cancelled);
+    }
+    if (payload.dice_pending !== undefined) {
+      _updateDicePendingBadge(payload.dice_pending);
+    }
+
     if (payload.stats) {
       updateStats(payload.stats);
       if (payload.stats.players && payload.stats.players.length > 0) {
@@ -5112,6 +5643,459 @@ function connect() {
 }
 
 connect();
+
+// ── Input-only mode for mobile players ───────────────────────────────────
+// Triggered by either:
+//   ?view=input              — explicit (long form, still supported)
+//   ?char=<Name>             — shorthand: char= alone implies input-only,
+//                              so players only need to type the short URL
+//                              (e.g. http://<host>:5001/?char=Mira).
+// Both forms set the character binding the same way (the binding is read
+// from ?character= or ?char= inside _initDicePad / _loadCharacterSheet).
+{
+  const _qp = new URLSearchParams(location.search);
+  const _inputMode = _qp.get('view') === 'input' || _qp.has('char') || _qp.has('character');
+  if (_inputMode) {
+    document.body.classList.add('input-only');
+    const ip = document.getElementById('input-panel');
+    if (ip) ip.classList.remove('collapsed');
+    _initInputTabs();
+    _initDicePad();
+  }
+}
+
+// ── Move / Roll tab switcher (input-only mode only) ──────────────────────
+function _initInputTabs() {
+  const body = document.getElementById('input-body');
+  if (!body) return;
+  document.querySelectorAll('.dp-tab').forEach(btn => {
+    btn.addEventListener('click', () => _setActiveTab(btn.dataset.tab));
+  });
+}
+
+function _setActiveTab(tab) {
+  if (tab !== 'move' && tab !== 'roll' && tab !== 'character') return;
+  const body = document.getElementById('input-body');
+  if (!body) return;
+  body.dataset.activeTab = tab;
+  document.querySelectorAll('.dp-tab').forEach(b => {
+    b.classList.toggle('active', b.dataset.tab === tab);
+  });
+  // Clear the "DM request waiting" dot once the player navigates to Roll.
+  if (tab === 'roll') {
+    const rollTab = document.querySelector('.dp-tab[data-tab="roll"]');
+    if (rollTab) rollTab.classList.remove('has-request');
+  }
+  // Lazy-load the character sheet the first time Sheet is opened, and refresh
+  // each subsequent open so HP / slots / conditions stay current with the
+  // campaign file (which the DM updates between turns).
+  if (tab === 'character') _loadCharacterSheet();
+}
+
+// ── Character sheet pane (Sheet tab) ─────────────────────────────────────
+async function _loadCharacterSheet() {
+  const status = document.getElementById('cp-status');
+  const bodyEl = document.getElementById('cp-body');
+  if (!status || !bodyEl) return;
+  // Resolve the character: prefer ?char= / ?character=, then localStorage / typed name.
+  const _qpCh = new URLSearchParams(location.search);
+  const ch = (_qpCh.get('char') || _qpCh.get('character')
+              || localStorage.getItem('dnd_player_name')
+              || '').trim();
+  if (!ch) {
+    status.textContent = 'No character bound — open with ?char=<Name>';
+    bodyEl.innerHTML = '';
+    return;
+  }
+  status.textContent = `Loading ${ch}…`;
+  try {
+    const res = await fetch(`/character/${encodeURIComponent(ch)}`, {
+      headers: _authHeaders(),
+    });
+    if (!res.ok) {
+      status.textContent = `Could not load sheet (${res.status})`;
+      bodyEl.innerHTML = '';
+      return;
+    }
+    const md = await res.text();
+    bodyEl.innerHTML = _renderMarkdown(md);
+    status.textContent = '';
+  } catch (e) {
+    status.textContent = `Network error — ${e.message || e}`;
+    bodyEl.innerHTML = '';
+  }
+}
+
+// Minimal markdown → HTML for character sheets. Supports the subset used in
+// the campaign template: # ## ### headers, **bold**, *italic*, - bullet lists,
+// and GitHub-style pipe tables. Not a full CommonMark implementation; deliberately
+// small so we don't drag in a dependency for one read-only viewer.
+function _renderMarkdown(md) {
+  const esc = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  const inline = (s) => esc(s)
+    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+    .replace(/(^|[\s(])\*([^*\n]+)\*/g, '$1<em>$2</em>')
+    .replace(/(^|[\s(])_([^_\n]+)_/g, '$1<em>$2</em>');
+
+  const lines = md.replace(/\r\n/g, '\n').split('\n');
+  const out = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    // Headers
+    let m = /^(#{1,3})\s+(.*)$/.exec(line);
+    if (m) { const lvl = m[1].length; out.push(`<h${lvl}>${inline(m[2])}</h${lvl}>`); i++; continue; }
+    // Horizontal rule
+    if (/^---+\s*$/.test(line)) { out.push('<hr>'); i++; continue; }
+    // Table — header row followed by separator row of dashes/pipes.
+    if (line.includes('|') && i + 1 < lines.length && /^\s*\|?\s*:?-{2,}.*\|/.test(lines[i+1])) {
+      const cells = (s) => s.replace(/^\s*\|/, '').replace(/\|\s*$/, '').split('|').map(c => c.trim());
+      const head = cells(line);
+      const rows = [];
+      i += 2;
+      while (i < lines.length && lines[i].includes('|')) { rows.push(cells(lines[i])); i++; }
+      let html = '<table><thead><tr>' + head.map(h => `<th>${inline(h)}</th>`).join('') + '</tr></thead><tbody>';
+      for (const r of rows) html += '<tr>' + r.map(c => `<td>${inline(c)}</td>`).join('') + '</tr>';
+      html += '</tbody></table>';
+      out.push(html);
+      continue;
+    }
+    // Bullet list
+    if (/^\s*-\s+/.test(line)) {
+      const items = [];
+      while (i < lines.length && /^\s*-\s+/.test(lines[i])) {
+        items.push(inline(lines[i].replace(/^\s*-\s+/, '')));
+        i++;
+      }
+      out.push('<ul>' + items.map(t => `<li>${t}</li>`).join('') + '</ul>');
+      continue;
+    }
+    // Blank line → paragraph break
+    if (line.trim() === '') { i++; continue; }
+    // Otherwise paragraph (collect consecutive non-blank, non-special lines)
+    const para = [line];
+    i++;
+    while (i < lines.length && lines[i].trim() !== '' && !/^#{1,3}\s/.test(lines[i])
+           && !/^\s*-\s+/.test(lines[i]) && !lines[i].includes('|')
+           && !/^---+\s*$/.test(lines[i])) {
+      para.push(lines[i]); i++;
+    }
+    out.push('<p>' + inline(para.join(' ')) + '</p>');
+  }
+  return out.join('\n');
+}
+
+// ── DM-side "Waiting on Piper, Mira…" badge for unresolved dice-requests ──
+// Driven by the server's dice_pending SSE event (snapshot of all active
+// requests). Hidden when the snapshot is empty.
+function _updateDicePendingBadge(snapshot) {
+  const badge = document.getElementById('dice-pending-badge');
+  if (!badge) return;
+  const entries = Array.isArray(snapshot) ? snapshot.filter(e => e && (e.pending || []).length) : [];
+  if (entries.length === 0) {
+    badge.classList.remove('visible');
+    badge.innerHTML = '';
+    return;
+  }
+  // Most recent request first (best-effort: snapshot order is insertion order on the server).
+  const lines = entries.map(e => {
+    const who   = (e.pending || []).join(', ');
+    const label = e.label ? `<span class="dpb-label">${e.label}</span>` : '';
+    return `Waiting on: ${who}${label}`;
+  }).join('<hr style="border:none;border-top:1px solid rgba(180,140,60,0.25);margin:6px 0">');
+  badge.innerHTML = lines;
+  badge.classList.add('visible');
+}
+
+// ── Phone dice pad: server-side roll + slot-machine reveal ───────────────
+function _initDicePad() {
+  const reel    = document.getElementById('dp-reel');
+  const rollBtn = document.getElementById('dp-roll');
+  const modVal  = document.getElementById('dp-mod-val');
+  const nameEl  = document.getElementById('dp-name');
+  const labelEl = document.getElementById('dp-label');
+  const boundEl = document.getElementById('dp-bound');
+  if (!reel || !rollBtn) return;
+
+  // Character binding: ?char=Piper (or ?character=Piper) locks this phone to
+  // that player. Without the param the phone falls back to a free-text name
+  // + localStorage. Short form (?char=) is preferred for hand-typed URLs.
+  const _qp = new URLSearchParams(location.search);
+  const _bound = (_qp.get('char') || _qp.get('character') || '').trim().slice(0, 24);
+  if (_bound) {
+    nameEl.value = _bound;
+    nameEl.classList.add('locked');
+    nameEl.setAttribute('readonly', '');
+    if (boundEl) {
+      boundEl.style.display = 'block';
+      boundEl.textContent = _bound;
+    }
+  } else {
+    nameEl.value = localStorage.getItem('dnd_player_name') || '';
+    nameEl.addEventListener('input', () => {
+      localStorage.setItem('dnd_player_name', nameEl.value.trim().slice(0, 24));
+    });
+  }
+
+  let spec = '1d20';
+  let adv  = 'normal';
+  let mod  = 0;
+  // Currently-active DM request, if any. Echoed back on the roll POST so the
+  // server can match the response to the pending request and release any
+  // blocking --wait call on the DM side.
+  let _activeRequestId = '';
+  reel.textContent = 'd20';
+
+  function _syncAdvAvailability() {
+    const isD20 = (spec === '1d20');
+    document.querySelectorAll('.dp-adv').forEach(b => {
+      if (isD20) b.removeAttribute('disabled');
+      else       b.setAttribute('disabled', '');
+    });
+    if (!isD20 && adv !== 'normal') {
+      adv = 'normal';
+      document.querySelectorAll('.dp-adv').forEach(b => b.classList.remove('active'));
+      const n = document.querySelector('.dp-adv[data-adv="normal"]');
+      if (n) n.classList.add('active');
+    }
+    const hint = document.getElementById('dp-hint');
+    if (hint) hint.style.opacity = isD20 ? '1' : '0.4';
+  }
+
+  document.querySelectorAll('#dp-die-row .dp-die').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('#dp-die-row .dp-die').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      spec = btn.dataset.spec;
+      if (!reel.classList.contains('spinning')) reel.textContent = spec.replace('1d', 'd');
+      _syncAdvAvailability();
+    });
+  });
+  _syncAdvAvailability();
+  document.querySelectorAll('.dp-adv').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('.dp-adv').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      adv = btn.dataset.adv;
+    });
+  });
+  document.querySelectorAll('.dp-mod').forEach(btn => {
+    btn.addEventListener('click', () => {
+      mod = Math.max(-30, Math.min(30, mod + Number(btn.dataset.delta)));
+      modVal.textContent = (mod >= 0 ? '+' : '') + mod;
+    });
+  });
+
+  // Slot-machine ticker: cycle random faces, ease the interval, then lock.
+  function spin(maxFace) {
+    return new Promise(resolve => {
+      reel.classList.add('spinning');
+      reel.classList.remove('locked');
+      let delay = 40;             // ms between ticks
+      const start = performance.now();
+      const minMs = 900;          // minimum spin duration
+      function tick() {
+        reel.textContent = String(1 + Math.floor(Math.random() * maxFace));
+        const elapsed = performance.now() - start;
+        delay = Math.min(260, 40 + elapsed * 0.25);   // ease out
+        if (elapsed > minMs && delay > 220) { resolve(); return; }
+        setTimeout(tick, delay);
+      }
+      tick();
+    });
+  }
+
+  function lockTo(value) {
+    reel.classList.remove('spinning');
+    reel.textContent = String(value);
+    // restart animation
+    reel.classList.remove('locked');
+    void reel.offsetWidth;
+    reel.classList.add('locked');
+  }
+
+  rollBtn.addEventListener('click', async () => {
+    const character = (nameEl.value || '').trim() || 'Player';
+    const label     = (labelEl.value || '').trim();
+    rollBtn.disabled = true;
+    document.getElementById('dp-result-line').textContent = '';
+
+    const m = /^(\d+)d(\d+)$/.exec(spec);
+    const faces = m ? Number(m[2]) : 20;
+
+    // Kick off spin animation immediately so the phone feels responsive,
+    // then await the authoritative server roll.
+    const spinPromise = spin(faces);
+    let result = null;
+    try {
+      const res = await fetch('/player-input/dice', {
+        method: 'POST',
+        headers: _authHeaders(),
+        body: JSON.stringify({
+          character, spec, modifier: mod, advantage: adv, label,
+          request_id: _activeRequestId || undefined,
+        }),
+      });
+      if (res.ok) result = await res.json();
+    } catch (_) { /* network error — fall through */ }
+
+    await spinPromise;
+    if (!result) {
+      reel.classList.remove('spinning');
+      reel.textContent = '!';
+      document.getElementById('dp-result-line').textContent = 'roll failed';
+      rollBtn.disabled = false;
+      rollBtn.classList.remove('pulse');
+      if (_locked) _setLocked(false);
+      return;
+    }
+
+    // Lock to the kept die value (single die) or the subtotal (multi-die).
+    const displayFace = (result.kept && result.kept.length === 1)
+      ? result.kept[0]
+      : result.subtotal;
+    lockTo(displayFace);
+
+    const line = document.getElementById('dp-result-line');
+    line.innerHTML = `${result.spec}${result.modifier ? (result.modifier > 0 ? '+' : '') + result.modifier : ''}` +
+                     ` &nbsp;→&nbsp; <span class="total">${result.total}</span>` +
+                     (result.both ? ` &nbsp;<span style="opacity:.7">(${result.both.join(' / ')} ${result.advantage})</span>` : '');
+    if (navigator.vibrate) navigator.vibrate(30);
+    rollBtn.classList.remove('pulse');
+    if (boundEl) {
+      // Clear the inline request line once the roll has been resolved.
+      const req = boundEl.querySelector('.req');
+      if (req) req.remove();
+    }
+
+    // If this was a prescribed (DM-requested) roll, keep the pad fully locked
+    // afterwards so the player can't fire another unsolicited roll. The lock
+    // is released only by the next dice_request arriving for this character
+    // (which unlocks + re-pre-fills inside _applyDiceRequest).
+    if (_activeRequestId) {
+      _setLocked(true, spec, adv);          // keep die / adv selections frozen
+      rollBtn.disabled = true;              // and disable Roll itself
+      rollBtn.classList.add('rolled');
+      if (boundEl) {
+        let done = boundEl.querySelector('.req');
+        if (!done) { done = document.createElement('span'); done.className = 'req'; boundEl.appendChild(done); }
+        done.textContent = '✓ Rolled — waiting for DM';
+      }
+      _activeRequestId = '';
+    } else {
+      // Free-roll path: unlock so the player can roll again freely.
+      rollBtn.disabled = false;
+      if (_locked) _setLocked(false);
+    }
+  });
+
+  // Lock the pad to a single prescribed roll. Only the matching die / adv
+  // button and the Roll button remain interactive. Cleared after the roll
+  // resolves (success or failure) so the player can free-roll again.
+  let _locked = false;
+  function _setLocked(active, keepSpec, keepAdv) {
+    _locked = !!active;
+    document.querySelectorAll('.dp-die').forEach(b => {
+      if (active && b.dataset.spec !== keepSpec) b.setAttribute('disabled', '');
+      else                                       b.removeAttribute('disabled');
+    });
+    document.querySelectorAll('.dp-adv').forEach(b => {
+      // Adv buttons are also gated by _syncAdvAvailability for non-d20 specs;
+      // re-syncing afterwards restores that behaviour.
+      if (active && b.dataset.adv !== keepAdv) b.setAttribute('disabled', '');
+      else                                     b.removeAttribute('disabled');
+    });
+    document.querySelectorAll('.dp-mod').forEach(b => {
+      if (active) b.setAttribute('disabled', '');
+      else        b.removeAttribute('disabled');
+    });
+    if (active) labelEl.setAttribute('readonly', '');
+    else        labelEl.removeAttribute('readonly');
+    if (!active) _syncAdvAvailability();
+  }
+
+  // ── DM → phone: react to a /dice-request broadcast ───────────────────────
+  function _applyDiceRequest(req) {
+    if (!req) return;
+    const me      = (nameEl.value || '').trim().toLowerCase();
+    const targets = Array.isArray(req.characters) && req.characters.length
+      ? req.characters.map(c => String(c).toLowerCase())
+      : [String(req.character || 'any').toLowerCase()];
+    const isAny   = targets.includes('any');
+    if (!isAny && !targets.includes(me)) return;                  // not for this phone
+
+    _activeRequestId = String(req.request_id || '');
+
+    // Spec → click the matching die button. If unknown, fall back to d20.
+    const reqSpec = (req.spec || '1d20').toLowerCase();
+    const dieBtn  = document.querySelector(`.dp-die[data-spec="${reqSpec}"]`)
+                 || document.querySelector('.dp-die[data-spec="1d20"]');
+    if (dieBtn) dieBtn.click();
+
+    // Adv/dis (only meaningful on 1d20; _syncAdvAvailability gates the rest).
+    const advBtn = document.querySelector(`.dp-adv[data-adv="${req.advantage || 'normal'}"]`);
+    if (advBtn && !advBtn.hasAttribute('disabled')) advBtn.click();
+
+    // Modifier — jump straight to the requested value rather than +/- ticking.
+    mod = Math.max(-30, Math.min(30, Number(req.modifier) || 0));
+    modVal.textContent = (mod >= 0 ? '+' : '') + mod;
+
+    // Label / DC line.
+    const baseLabel = (req.label || '').trim();
+    labelEl.value = baseLabel;
+    if (boundEl) {
+      const dcStr = (req.dc != null) ? ` · DC ${req.dc}` : '';
+      const desc  = baseLabel || (reqSpec === '1d20' ? 'Roll d20' : `Roll ${reqSpec}`);
+      let r = boundEl.querySelector('.req');
+      if (!r) { r = document.createElement('span'); r.className = 'req'; boundEl.appendChild(r); }
+      r.textContent = `↻ ${desc}${dcStr}`;
+    }
+
+    rollBtn.disabled = false;                 // re-enable after a previous "rolled" lock
+    rollBtn.classList.remove('rolled');
+    rollBtn.classList.add('pulse');
+    if (navigator.vibrate) navigator.vibrate([20, 60, 20]);
+
+    // Lock everything except the prescribed die + adv button + Roll.
+    _setLocked(true, reqSpec, (req.advantage || 'normal'));
+
+    // Pull the player to the Roll tab so they don't miss the request. If they
+    // were already on Roll, this is a no-op; if they were on Move, the tab
+    // switches and the dot on the Roll button is cleared by _setActiveTab.
+    const onMove = document.getElementById('input-body')?.dataset.activeTab === 'move';
+    if (onMove) {
+      const rollTab = document.querySelector('.dp-tab[data-tab="roll"]');
+      if (rollTab) rollTab.classList.add('has-request');
+      _setActiveTab('roll');
+    }
+  }
+  window._onDiceRequest = _applyDiceRequest;
+
+  // DM cancelled the active prescribed roll (e.g. via DELETE /dice-request/<id>).
+  // Server broadcasts {dice_request_cancelled: <request_id>}. If it matches
+  // this phone's active request, fully unlock the pad so the player isn't
+  // stuck staring at a locked Roll button while the badge has already cleared.
+  // Cancellations for other phones (or for requests we never received) are
+  // safely ignored.
+  function _onDiceRequestCancelled(rid) {
+    if (!rid || rid !== _activeRequestId) return;
+    _activeRequestId = '';
+    if (_locked) _setLocked(false);
+    rollBtn.disabled = false;
+    rollBtn.classList.remove('pulse', 'rolled');
+    if (boundEl) {
+      const r = boundEl.querySelector('.req');
+      if (r) r.remove();
+    }
+    // Brief inline confirmation so the player sees the unlock happened.
+    const line = document.getElementById('dp-result-line');
+    if (line) {
+      line.textContent = '— request cancelled by DM —';
+      setTimeout(() => { if (line.textContent === '— request cancelled by DM —') line.textContent = ''; }, 4000);
+    }
+  }
+  window._onDiceRequestCancelled = _onDiceRequestCancelled;
+}
 </script>
 </body>
 </html>

--- a/scripts/dice_player.py
+++ b/scripts/dice_player.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""dice_player.py — route a PC-attached dice roll through the display companion.
+
+Mirrors `dice.py` syntax for the spec + advantage tokens, but instead of rolling
+locally (or routing to the optional port-7777 physical-dice server), this POSTs
+a `/dice-request` to the display companion at port 5001 and blocks until the
+player taps Roll on their phone. The roll itself is rolled server-side with
+`secrets.randbelow`, broadcast as a `dice:true` feed entry on the main display,
+and printed to stdout here in a `dice.py`-shaped result line so any DM tooling
+that consumes dice.py's stdout will keep working.
+
+Usage:
+    python3 dice_player.py d20+5 --player piper --label "Stealth check"
+    python3 dice_player.py d20 adv --player mira --label "Initiative"
+    python3 dice_player.py d20+3 dis --player piper --label "Concentration save"
+    python3 dice_player.py 2d6+3 --player mira --label "Greataxe damage"
+    python3 dice_player.py 1d100 --player piper --label "Wild Magic Surge" --dc 50
+
+Requires `--player <name>` (the phone's bound character). Without a phone
+target, use `dice.py` instead. Exits 1 on network error, 2 on phone timeout.
+
+Spec parsing matches dice.py: NdM ± K (default N=1), with optional `adv`/`dis`
+tokens as separate positional arguments.
+"""
+
+import argparse
+import json
+import os
+import re
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.request
+
+DISPLAY_DIR = os.path.expanduser("~/.claude/skills/dnd/display")
+TOKEN_FILE  = os.path.join(DISPLAY_DIR, ".token")
+SCHEME_FILE = os.path.join(DISPLAY_DIR, ".scheme")
+TIMEOUT     = 8.0
+
+# Match the scheme the display server is using (HTTP default, HTTPS if --tls).
+try:
+    with open(SCHEME_FILE) as f:
+        _SCHEME = f.read().strip() or "http"
+except FileNotFoundError:
+    _SCHEME = "http"
+_BASE       = f"{_SCHEME}://localhost:5001"
+_DICE_REQ   = f"{_BASE}/dice-request"
+_TEXT_LOG   = os.path.join(DISPLAY_DIR, "text_log.json")
+
+_SSL_CTX: "ssl.SSLContext | None" = None
+if _SCHEME == "https":
+    _SSL_CTX = ssl.create_default_context()
+    _SSL_CTX.check_hostname = False
+    _SSL_CTX.verify_mode = ssl.CERT_NONE
+
+
+def _read_token() -> str:
+    try:
+        with open(TOKEN_FILE) as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        return ""
+
+
+def _parse_spec(raw: str) -> "tuple[str, int]":
+    """Accept dice.py-style specs: d20, 1d20, 2d6+3, d100-5, d20+0.
+
+    Returns (canonical_spec, modifier). Canonical spec is always NdM with N>=1.
+    Modifier can be negative.
+    """
+    s = raw.strip().lower().replace(" ", "")
+    m = re.fullmatch(r"(\d*)d(\d+)([+-]\d+)?", s)
+    if not m:
+        raise ValueError(f"bad spec {raw!r} — expected forms like d20, 1d20+5, 2d6-1")
+    n = int(m.group(1) or 1)
+    sides = int(m.group(2))
+    mod = int(m.group(3)) if m.group(3) else 0
+    return f"{n}d{sides}", mod
+
+
+def _post(url: str, body: dict, token: str) -> dict:
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["X-DND-Token"] = token
+    req = urllib.request.Request(url, data=json.dumps(body).encode(), headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=TIMEOUT, context=_SSL_CTX) as resp:
+        return json.loads(resp.read().decode("utf-8") or "{}")
+
+
+def _get(url: str, token: str) -> dict:
+    headers = {"X-DND-Token": token} if token else {}
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    with urllib.request.urlopen(req, timeout=TIMEOUT, context=_SSL_CTX) as resp:
+        return json.loads(resp.read().decode("utf-8") or "{}")
+
+
+def _delete(url: str, token: str) -> None:
+    headers = {"X-DND-Token": token} if token else {}
+    req = urllib.request.Request(url, headers=headers, method="DELETE")
+    try:
+        urllib.request.urlopen(req, timeout=TIMEOUT, context=_SSL_CTX)
+    except Exception:
+        pass
+
+
+def _find_resolved_roll(character: str, spec: str, since_ts: float) -> "dict | None":
+    """Scan text_log.json for the matching dice entry written since `since_ts`.
+
+    The /dice-request flow doesn't push the resolved roll back through the
+    request endpoint — the phone POSTs to /player-input/dice, which broadcasts
+    and appends to text_log. The wrapper reads it back from the on-disk log.
+    Match heuristic: most recent `dice:true` entry whose text starts with
+    `<character> rolls <spec>`.
+    """
+    try:
+        with open(_TEXT_LOG) as f:
+            log = json.load(f)
+    except FileNotFoundError:
+        return None
+    # We can't compare timestamps because text_log entries don't carry them —
+    # scan from newest backward and pick the first match.
+    needle = f"{character} rolls {spec}"
+    for entry in reversed(log):
+        if entry.get("dice") and entry.get("text", "").startswith(needle):
+            return entry
+    return None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Route a player-character dice roll through the display companion."
+    )
+    parser.add_argument("spec", help="Dice spec like d20, 2d6+3, 1d20-2")
+    parser.add_argument("adv_dis", nargs="?", default="",
+                        help="Optional advantage marker: adv, advantage, dis, disadvantage")
+    parser.add_argument("--player", required=True, metavar="NAME",
+                        help="Phone-bound character (case-insensitive). REQUIRED.")
+    parser.add_argument("--label", default="", metavar="TEXT",
+                        help='Human label shown on the phone (e.g. "Stealth check").')
+    parser.add_argument("--dc", type=int, default=None, metavar="N",
+                        help="Optional DC for informational display on the phone.")
+    parser.add_argument("--timeout", type=int, default=600, metavar="SECONDS",
+                        help="Seconds to wait for the player to roll (default 600).")
+    args = parser.parse_args()
+
+    try:
+        spec, modifier = _parse_spec(args.spec)
+    except ValueError as e:
+        print(f"dice_player.py: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    adv_token = args.adv_dis.lower()
+    if adv_token in ("adv", "advantage"):
+        advantage = "advantage"
+    elif adv_token in ("dis", "disadvantage"):
+        advantage = "disadvantage"
+    elif adv_token == "":
+        advantage = "normal"
+    else:
+        print(f"dice_player.py: unknown adv/dis token {args.adv_dis!r}", file=sys.stderr)
+        sys.exit(1)
+
+    token = _read_token()
+    body = {
+        "characters": [args.player],
+        "spec": spec,
+        "modifier": modifier,
+        "advantage": advantage,
+    }
+    if args.label: body["label"] = args.label
+    if args.dc is not None: body["dc"] = args.dc
+
+    try:
+        resp = _post(_DICE_REQ, body, token)
+    except urllib.error.HTTPError as e:
+        print(f"dice_player.py: HTTP {e.code}: {e.read().decode('utf-8', 'replace')[:200]}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"dice_player.py: network error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    request_id = resp.get("request_id", "")
+    if not request_id:
+        print("dice_player.py: server did not return a request_id", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"dice_player.py: waiting on {args.player} ({spec}"
+          f"{'+'+str(modifier) if modifier>0 else (str(modifier) if modifier<0 else '')}"
+          f"{', '+advantage if advantage != 'normal' else ''}"
+          f"{', DC '+str(args.dc) if args.dc is not None else ''}"
+          f") — request_id={request_id}",
+          file=sys.stderr)
+
+    # Poll until the pending set drains (player rolled) or timeout.
+    started = time.time()
+    while time.time() - started < max(1, args.timeout):
+        try:
+            status = _get(f"{_DICE_REQ}/{request_id}", token)
+        except Exception as e:
+            print(f"dice_player.py: poll error ({e}) — retrying", file=sys.stderr)
+            time.sleep(1.0)
+            continue
+        if status.get("complete"):
+            break
+        time.sleep(0.5)
+    else:
+        # Timeout: cancel the pending request so the phone doesn't stay locked.
+        _delete(f"{_DICE_REQ}/{request_id}", token)
+        print(f"dice_player.py: timeout after {args.timeout}s — request cancelled, phone unlocked.",
+              file=sys.stderr)
+        sys.exit(2)
+
+    # Pull the resolved roll back from text_log for the dice.py-style stdout line.
+    rolled = _find_resolved_roll(args.player, spec, started)
+    if rolled is None:
+        # Roll happened but we couldn't find it; still report success.
+        print(f"dice_player.py: roll completed but text_log lookup failed", file=sys.stderr)
+        sys.exit(0)
+
+    # dice.py-style stdout: just the resolved text line, so any caller piping
+    # this into another tool sees the same shape it would from dice.py.
+    print(rolled.get("text", ""))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
> Drafting per the Discussion #36 thread — bundled patchset with Bobby's review-skill findings already applied. Marked as draft because Ethan wants another local-table round before this is merge-ready.

## Summary

Eight numbered patches that add a phone-side player companion to the existing Flask + SSE display, plus a DM-side synchronization layer:

- `?view=input` and `?char=<Name>` URL bindings (one phone per character).
- Three-tab phone layout: **Move** (action input) / **Roll** (server-side dice) / **Sheet** (read-only character sheet rendered from the campaign's `.md`).
- `POST /player-input/dice` rolls server-side with `secrets.randbelow`; slot-machine reveal locks on the authoritative value.
- `POST /dice-request` lets the DM/Claude prescribe a roll to one or more named characters — their phones pre-fill (die, modifier, adv/dis, label, optional DC), lock all controls except Roll, pulse the Roll button. Pad stays locked after a prescribed roll resolves to prevent unsolicited follow-ups.
- `send.py --dice-request --wait` blocks the DM until every prescribed character rolls (polls `GET /dice-request/<id>`). Exits 2 on timeout with a clean `DELETE` of the request.
- Main display "Waiting on…" badge driven by `dice_pending` SSE, replayed on `/stream` connect.
- New `scripts/dice_player.py` wrapper taking `dice.py`-style syntax (`d20+5 --player piper --label \"Stealth check\"`) so the DM has a familiar CLI that routes through `/dice-request` instead of the optional port-7777 physical-dice path.

Full handoff doc, design rationale, install steps, smoke test, caveats:
**https://gist.github.com/Ethros19/6dd33698c068384f37cc6466273ca4ae**

## Review-skill findings (applied)

Both items from your review pass on the Gist are addressed in this branch:

- **`data/dnd5e_supplemental.json` build-artifact leak** — reverted to upstream. The stub entries (\"Damage\", \"Notes\", \"Slashing\", etc.) generated by the `build_supplemental.py --character` false-positive are no longer in the diff.
- **`/character/<name>` path-traversal vector via `camp`** — added the matching allowlist scrub. The `camp` value pulled from `CAMP_FILE` now passes through `re.sub(r\"[^A-Za-z0-9_-]\", \"\", camp)[:50]` before any `os.path.join`. Same allowlist + length cap as the character argument.

## Rebase

Diff was originally drafted against `ac682b8` (the chore commit that didn't survive your history rewrite to AGPL). This branch is rebased against `19d2bbd` (current `main`, v1.10.0 with TTS). `git apply` clean against `19d2bbd`.

## Security model (unchanged from upstream)

- All new endpoints token-gated with `X-DND-Token`.
- `secrets.randbelow` for all dice; no path that reaches `random.random()` or equivalent.
- Input validation on every endpoint: spec regex-checked, modifier ±100-clamped, character names allowlisted + length-capped, campaign name allowlisted + length-capped.
- No public-internet exposure intended; LAN-mode + token trust boundary unchanged.

## Smoke tests run locally (this branch, against `19d2bbd`)

- Two phones, two characters, two simultaneous prescribed rolls with different modifiers — drained cleanly, `send.py --wait` released on schedule.
- Lock-after-roll verified: after a prescribed roll lands, the pad shows \"✓ Rolled — waiting for DM\" until the next `dice_request` for that character.
- Phone-unlock-on-DM-cancel verified: `DELETE /dice-request/<id>` broadcasts `dice_request_cancelled`; phone JS picks it up and unlocks.
- `dice_player.py` happy path: spec parsing (`d20`, `1d20+5`, `2d6-1`, `1d100`), POSTs `/dice-request`, polls, reads resolved roll from `text_log.json`, prints in `dice.py` stdout shape, exits 0.
- `dice_player.py` timeout path: cancels the pending request via `DELETE` (which also unlocks the phone), exits 2.

## Why draft

Ethan wants one more table-side session against this branch before flipping to ready-for-review — to shake out any UX edge cases on the new tab nav with real combat pacing. Will mark ready when that lands.

## Files touched

| File | Change |
|---|---|
| `display/dnd-display-app.py` | +298 — `POST /player-input/dice`, `POST /dice-request`, `GET/DELETE /dice-request/<id>`, `GET /character/<name>`, `_dice_pending` registry, SSE replay on connect |
| `display/send.py` | +102 — `--dice-request` + `--wait` flags, blocking poll loop |
| `display/templates/index.html` | +1004 — phone dice pad, three-tab layout (Move / Roll / Sheet), waiting badge, inline markdown renderer, all gated by `body.input-only` |
| `scripts/dice_player.py` | +227 (new) — `dice.py`-syntax wrapper routing through `/dice-request` |

🤖 Drafted with [Claude Code](https://claude.com/claude-code)