### PR TITLE
feat(display): on-screen dice roller for no-phones games

### DIFF
--- a/skills/dnd/SKILL.md
+++ b/skills/dnd/SKILL.md
@@ -267,6 +267,9 @@ Do NOT run the autorun wait when: combat is resolving individual turns, a dice r
 Roll handling is chosen at game start and stored as `roll_mode` in `state.md → ## Session Flags` (default **players**). Read it at every `/dm:dnd load` and honor it all session:
 
 - **`roll_mode: players` (default) — players roll their own PCs.** For *any* PC d20 (attack, skill/ability check, save, death save), **call for the roll by name and STOP — wait for the player's result before resolving.** Do **not** roll it for them. ⚠ **Never fall back to `dice.py` or an `[auto]` result for a PC** just because the physical-dice phone server isn't running — if no roll comes back, ask the player for the number out loud. You roll **only** NPC/monster dice. (This is a hard constraint: silently auto-rolling a PC is the #1 thing players notice and dislike.)
+  - **Prescribe the roll through the display when it's running** (`_display_running = true`): call
+    `python3 ${CLAUDE_SKILL_DIR}/display/send.py --dice-request --character "<PC>" --spec 1dN [--modifier ±M] [--advantage advantage|disadvantage] [--label "<check>"] [--dc N] --wait`.
+    The roll routes to that PC's **phone** if one is bound, or **auto-opens the on-screen Dice drawer** on the shared screen when no phone is bound (or the display's *Roll on screen* setting is on) — the same roller either way. `--wait` blocks until the player rolls and then prints their result for you to resolve (it exits non-zero on timeout — fall back to asking out loud). When the display is **not** running, just call for the roll verbally and wait. Never roll the PC yourself under `players`.
 - **`roll_mode: auto` — you roll everything openly.** Resolve PC d20s yourself via `dice.py` and show full math inline (`Piper — Perception: d20+5 = 18 → …`), no waiting. For solo / fast play.
 
 **Initiative** is always DM-rolled via `combat.py init` for all combatants (PCs and NPCs) regardless of `roll_mode`.

--- a/skills/dnd/display/dnd-display-app.py
+++ b/skills/dnd/display/dnd-display-app.py
@@ -841,6 +841,20 @@ def _detect_scene(text: str) -> Optional[dict]:
 
 _clients: list[queue.Queue] = []
 _clients_lock = threading.Lock()
+# Maps a connected SSE client (queue) → the character it's bound to, if any.
+# Phones connect to /stream?character=<name>; the main display has no character.
+# Lets a dice-request know whether a target PC has a live phone (→ route there)
+# or not (→ open the on-screen roller). Guarded by _clients_lock.
+_client_chars: "dict[queue.Queue, str]" = {}
+
+
+def _phone_present(char: str) -> bool:
+    """True if some connected phone is bound to this character (case-insensitive)."""
+    c = (char or "").strip().lower()
+    if not c:
+        return False
+    with _clients_lock:
+        return c in _client_chars.values()
 
 # ─── Text replay log ──────────────────────────────────────────────────────────
 # Stores the last N cleaned text chunks so late-connecting browsers can catch up.
@@ -1101,6 +1115,7 @@ def _broadcast(payload: dict) -> None:
                 dead.append(q)
         for q in dead:
             _clients.remove(q)
+            _client_chars.pop(q, None)
 
 
 # ─── Routes ──────────────────────────────────────────────────────────────────
@@ -2144,11 +2159,14 @@ def dice_request():
             }
         _broadcast({"dice_pending": _dice_pending_snapshot()})
 
+    # Targets with no live phone bound → the main display should roll on-screen.
+    onscreen_targets = [c for c in chars if c.lower() != "any" and not _phone_present(c)]
     payload = {
         "dice_request": {
             "request_id": request_id,
             "characters": chars,
             "character": chars[0] if len(chars) == 1 else "any",   # legacy single-target field
+            "onscreen_targets": onscreen_targets,
             "spec": spec,
             "modifier": modifier,
             "advantage": adv,
@@ -2489,6 +2507,11 @@ def stream():
     q: queue.Queue = queue.Queue(maxsize=256)
     with _clients_lock:
         _clients.append(q)
+        # Register this client's bound character (phones pass ?character=/?char=);
+        # the main display passes neither. Drives dice-request phone-vs-screen routing.
+        _ch = (request.args.get("character") or request.args.get("char") or "").strip().lower()[:48]
+        if _ch:
+            _client_chars[q] = _ch
 
     # Send the current scene immediately on connect so the browser
     # starts with the right background even mid-session.
@@ -2538,6 +2561,7 @@ def stream():
             "request_id": rid,
             "characters": chars,
             "character": chars[0] if len(chars) == 1 else "any",
+            "onscreen_targets": [c for c in chars if c.lower() != "any" and not _phone_present(c)],
             "spec": meta.get("spec", "1d20"),
             "modifier": meta.get("modifier", 0),
             "advantage": meta.get("advantage", "normal"),
@@ -2573,6 +2597,7 @@ def stream():
                     _clients.remove(q)
                 except ValueError:
                     pass
+                _client_chars.pop(q, None)
 
     resp = Response(
         generate(),

--- a/skills/dnd/display/templates/index.html
+++ b/skills/dnd/display/templates/index.html
@@ -3477,6 +3477,10 @@
     <span class="audio-label">Style</span>
     <span id="skin-label" class="theme-label">Vellum</span>
   </div>
+  <div class="audio-row" id="onscreen-dice-row" title="Open the dice roller on this screen when the DM calls for a roll (for games without phones)">
+    <span class="audio-label">Roll on screen</span>
+    <div class="toggle-track" id="osd-track"><div class="toggle-thumb"></div></div>
+  </div>
   <div class="audio-row" id="textsize-row" title="Reading text size — font size, not page zoom">
     <span class="audio-label">Text Size</span>
     <span class="ts-stepper">
@@ -6015,6 +6019,23 @@ async function _playSfx(name) {
   } catch (_) {}
 }
 
+// "Roll on screen" toggle — when on, a DM-prescribed roll auto-opens the Dice
+// drawer on this display (for games with no phones). Persisted per-browser;
+// _onscreenDiceOn() reads the same flag.
+(function _initOnscreenDiceToggle() {
+  const row = document.getElementById('onscreen-dice-row');
+  const track = document.getElementById('osd-track');
+  if (!row || !track) return;
+  let on = false;
+  try { on = localStorage.getItem('dnd-onscreen-dice') === '1'; } catch (_) {}
+  _setTrack(track, on);
+  row.addEventListener('click', () => {
+    on = !on;
+    _setTrack(track, on);
+    try { localStorage.setItem('dnd-onscreen-dice', on ? '1' : '0'); } catch (_) {}
+  });
+})();
+
 document.getElementById('sfx-row').addEventListener('click', () => {
   _sfxOn = !_sfxOn;
   _setTrack(_sfxTrack, _sfxOn);
@@ -6972,7 +6993,12 @@ let evtSource = null;
 let reconnectDelay = 1000;
 
 function connect() {
-  evtSource = new EventSource('/stream');
+  // Announce this client's bound character (phones only) so the server can tell
+  // whether a prescribed roll's target has a live phone (→ route there) or not
+  // (→ open the on-screen roller). The main display passes no character.
+  const _sp = new URLSearchParams(location.search);
+  const _streamChar = (_sp.get('char') || _sp.get('character') || '').trim();
+  evtSource = new EventSource('/stream' + (_streamChar ? ('?character=' + encodeURIComponent(_streamChar)) : ''));
 
   evtSource.onopen = () => {
     reconnectDelay = 1000;
@@ -7160,7 +7186,11 @@ connect();
         const tgt = (req && req.characters && req.characters[0]) || (req && req.character) || '';
         if (_nameEl && tgt && tgt.toLowerCase() !== 'any') _nameEl.value = tgt;
         if (typeof _prefill === 'function') _prefill(req);
-        if (_onscreenDiceOn() && typeof window._edOpenDrawer === 'function') window._edOpenDrawer('dice-drawer');
+        // Open when on-screen rolling is forced on (Settings), OR auto-detected:
+        // the server marks targets with no live phone in onscreen_targets.
+        const noPhone = Array.isArray(req && req.onscreen_targets)
+          && req.onscreen_targets.some(c => String(c).toLowerCase() === String(tgt).toLowerCase());
+        if ((_onscreenDiceOn() || noPhone) && typeof window._edOpenDrawer === 'function') window._edOpenDrawer('dice-drawer');
       };
     }
   }

--- a/skills/dnd/display/templates/index.html
+++ b/skills/dnd/display/templates/index.html
@@ -3153,6 +3153,25 @@
     border-left:1px solid var(--e-hair-strong); box-shadow:-2px 0 50px rgba(0,0,0,.4);
     transition:transform .32s cubic-bezier(.4,0,.1,1); }
   :root[data-skin="editorial"] body:not(.input-only) #audio-controls.ed-open{ transform:translateX(0); }
+
+  /* DICE drawer — hosts the relocated phone #dice-pad on the TV view, slides in
+     from the right like the other drawers. Editorial-only (the rail is too). */
+  #dice-drawer{ display:none; }
+  :root[data-skin="editorial"] body:not(.input-only) #dice-drawer{
+    display:flex; position:fixed; top:0; bottom:0; right:0; left:auto; transform:translateX(102%);
+    width:var(--ed-drawer-w); height:100vh; z-index:32; flex-direction:column;
+    background:var(--e-strong); color:var(--e-on-strong);
+    border-left:1px solid var(--e-hair-strong); box-shadow:-2px 0 50px rgba(0,0,0,.4);
+    transition:transform .32s cubic-bezier(.4,0,.1,1); }
+  :root[data-skin="editorial"] body:not(.input-only) #dice-drawer.ed-open{ transform:translateX(0); }
+  :root[data-skin="editorial"] body:not(.input-only) #dice-drawer::before{
+    content:"Dice"; display:block; padding:18px 18px 13px;
+    font-family:'Syne',sans-serif; font-weight:800; font-size:11px; letter-spacing:.28em;
+    text-transform:uppercase; color:var(--e-accent); border-bottom:1px solid var(--e-hair-strong); }
+  /* Show the relocated pad inside the drawer (overrides the base #dice-pad{display:none}). */
+  :root[data-skin="editorial"] body:not(.input-only) #dice-drawer #dice-pad{
+    display:flex !important; flex-direction:column; gap:12px; padding:18px 18px 22px;
+    border-top:0; background:transparent; flex:1 1 auto; overflow-y:auto; }
   :root[data-skin="editorial"] body:not(.input-only) #audio-controls::before{
     content:"Settings"; display:block; padding:18px 18px 13px;
     font-family:'Syne',sans-serif; font-weight:800; font-size:11px; letter-spacing:.28em; color:var(--e-accent);
@@ -3479,10 +3498,18 @@
   <button class="ed-launch" id="ed-launch-input" type="button" data-drawer="input-panel" title="Party input">
     <span class="ed-ic">✎</span><span>Party</span>
   </button>
+  <button class="ed-launch" id="ed-launch-dice" type="button" data-drawer="dice-drawer" title="Dice roller">
+    <span class="ed-ic">⚄</span><span>Dice</span>
+  </button>
   <button class="ed-launch" id="ed-launch-settings" type="button" data-drawer="audio-controls" title="Display settings">
     <span class="ed-ic">⚙</span><span>Settings</span>
   </button>
 </div>
+
+<!-- On-screen dice drawer (no-phones / internal games). The phone #dice-pad is
+     relocated into this drawer on the TV view, so the roller is the same component
+     players use on their phones. Slides in from the right like the other drawers. -->
+<div id="dice-drawer"></div>
 
 <!-- Phone first-screen: pick which character this device controls (shown when input
      view is opened without a ?char= binding, e.g. via the Phone Mode button). -->
@@ -7114,9 +7141,34 @@ connect();
     _refreshPhoneStatus();   // seed the turn-status strip
     // No character bound yet → show the first-screen picker (Phone Mode flow).
     if (!_qp.has('char') && !_qp.has('character')) _initCharSelect();
+  } else {
+    // Main / TV view — host the same phone dice pad in the slide-out "Dice" drawer.
+    // Relocate the real #dice-pad node into the drawer, then init it so the roller
+    // (reel, adv, modifier, prescribed-roll prefill) is identical to the phone.
+    const _dd = document.getElementById('dice-drawer');
+    const _pad = document.getElementById('dice-pad');
+    if (_dd && _pad) {
+      _dd.appendChild(_pad);
+      _initDicePad();   // binds handlers + sets window._onDiceRequest = _applyDiceRequest
+      // Auto-slide the drawer open when the DM prescribes a roll (when enabled).
+      // The shared screen has no character binding, so adopt whoever the DM
+      // prescribed into the name field — that satisfies the pad's target match
+      // and labels the roll correctly.
+      const _prefill = window._onDiceRequest;
+      const _nameEl = _pad.querySelector('#dp-name');
+      window._onDiceRequest = (req) => {
+        const tgt = (req && req.characters && req.characters[0]) || (req && req.character) || '';
+        if (_nameEl && tgt && tgt.toLowerCase() !== 'any') _nameEl.value = tgt;
+        if (typeof _prefill === 'function') _prefill(req);
+        if (_onscreenDiceOn() && typeof window._edOpenDrawer === 'function') window._edOpenDrawer('dice-drawer');
+      };
+    }
   }
   _initModeSwitcher(_inputMode);
 }
+// Should a prescribed roll auto-open the Dice drawer? Settings override flag;
+// no-phone auto-detect is layered on in a follow-up step.
+function _onscreenDiceOn() { try { return localStorage.getItem('dnd-onscreen-dice') === '1'; } catch (_) { return false; } }
 
 // ── Editorial right-rail drawers (TV view) + phone settings popover ──────────
 (function _initEditorialChrome() {
@@ -7140,7 +7192,7 @@ connect();
       '</svg>' +
       '</span> <span class="ed-lbl">Phone</span>';
     const launchers = Array.from(rail.querySelectorAll('.ed-launch'));
-    const drawerIds = ['input-panel', 'audio-controls'];
+    const drawerIds = ['input-panel', 'audio-controls', 'dice-drawer'];
 
     function closeAll() {
       drawerIds.forEach(id => {
@@ -7171,6 +7223,11 @@ connect();
     }));
     scrim.addEventListener('click', closeAll);
     document.addEventListener('keydown', e => { if (e.key === 'Escape') closeAll(); });
+    // Let other code (e.g. an incoming DM dice-request) slide a drawer open.
+    window._edOpenDrawer = (id) => {
+      const el = document.getElementById(id);
+      if (el && !el.classList.contains('ed-open')) toggle(id);
+    };
   }
 
   // Phone-only display settings — reuse the hidden Theme / Style pickers so each


### PR DESCRIPTION
**Draft for review** — opening per your "open it against the new home and I'll review it the same way" note. No `VERSION`/`CHANGELOG` bump yet; I'll leave release packaging / version line to you (there's a v2.2 in flight via #45/#46, and this is orthogonal to the themes).

## What this adds
On-screen dice rolling for **games with no phone companions** — everyone shares one screen. Builds directly on the `roll_mode` work from v2.1.1 (#43).

A fifth **Dice** launcher on the editorial rail slides out a drawer that hosts **the actual phone `#dice-pad`** — relocated into the drawer and `_initDicePad()`'d on the TV view, so the reel, die grid, advantage, modifier, label, prescribed-roll prefill and lock behaviour are identical to what players use on their phones. Zero screen space when closed.

## How a prescribed roll routes
The DM prescribes a `players`-mode roll via `send.py --dice-request … --wait` (now wired into SKILL.md). The server tracks which characters have a live phone bound (`/stream?character=`), and:

- **Phone bound to that PC** → routes to the phone (TV stays closed).
- **No phone** → the TV **auto-opens** the Dice drawer, pre-filled.
- **Settings → "Roll on screen"** forces on-screen rolling regardless (override).

Either surface rolls through the existing `POST /player-input/dice` (server rolls authoritatively, resolves the `request_id`, releases the DM's `--wait`, drops the result pill) — no new roll path.

## Scope / notes
- Editorial-skin-only (the rail is editorial-only by design); Vellum is unaffected.
- Opt-in: nothing changes unless a phone-less `players`-mode roll is prescribed or the override is on.
- Verified end-to-end with a real second (phone) client: phone-present routes to phone, phone-absent opens the TV drawer, manual open via the Dice button, and a full roll resolving the request.

## Commits
- on-screen dice as a slide-out rail drawer (mirrors phone pad)
- Roll-on-screen toggle + no-phone auto-detect routing (backend presence)
- SKILL.md: prescribe players-mode rolls via --dice-request

🤖 Generated with [Claude Code](https://claude.com/claude-code)
