### PR TITLE
feat(display): dropdown picker for Style row (scales to N skins)

### DIFF
--- a/skills/dnd/display/templates/index.html
+++ b/skills/dnd/display/templates/index.html
@@ -17,6 +17,19 @@
        "auto"  → defer to prefers-color-scheme (no data-theme attribute set)
      Persisted to localStorage["dnd-theme"]; matches the picker logic below. -->
 <script>
+  // Skin registry — shared by the anti-FOUC below and the picker logic in body.
+  // Adding a new skin (incl. an editorial overlay) is one entry here. Flat skins
+  // need only {id, label}. Overlay skins (token variants on the editorial bones,
+  // per #46) carry base:'editorial' so structural CSS resolves, and variant:'<id>'
+  // so token blocks scoped to data-variant apply on top.
+  //   { id:'vellum',    label:'Vellum'    }                                                   // flat
+  //   { id:'editorial', label:'Editorial' }                                                   // flat
+  //   { id:'gaslamp',   label:'Gaslamp',  base:'editorial', variant:'gaslamp' }   // overlay (future)
+  window._SKINS = [
+    { id: 'vellum',    label: 'Vellum'    },
+    { id: 'editorial', label: 'Editorial' },
+  ];
+
   (function () {
     try {
       var v = window.localStorage.getItem('dnd-theme');
@@ -24,11 +37,23 @@
         document.documentElement.setAttribute('data-theme', v);
       }
       // 'auto' or missing → leave the attribute off; CSS @media handles it.
-      // Skin axis: "vellum" (default, attr absent) or "editorial" (Colossal redesign).
-      var sk = window.localStorage.getItem('dnd-skin');
-      if (sk === 'editorial') {
-        document.documentElement.setAttribute('data-skin', 'editorial');
+
+      // Resolve the stored skin id to its (base, variant) attribute pair.
+      // Vellum is the structural default (no data-skin attr). Flat skins set
+      // data-skin to their own id. Overlays set data-skin to base AND
+      // data-variant to variant — mirrored in _apply() so the anti-FOUC and
+      // the picker stay in lockstep.
+      var skId = window.localStorage.getItem('dnd-skin');
+      var sk = null;
+      for (var i = 0; i < window._SKINS.length; i++) {
+        if (window._SKINS[i].id === skId) { sk = window._SKINS[i]; break; }
       }
+      if (sk) {
+        var base = sk.base || sk.id;
+        if (base !== 'vellum') document.documentElement.setAttribute('data-skin', base);
+        if (sk.variant) document.documentElement.setAttribute('data-variant', sk.variant);
+      }
+
       // Reading text size — a font-size multiplier (not page zoom). Applied here
       // to avoid a flash at the default size before the picker JS runs.
       var ts = parseFloat(window.localStorage.getItem('dnd-text-scale'));
@@ -1364,7 +1389,9 @@
     -moz-appearance: none;
     appearance: none;
     padding-right: 16px;
-    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6'><path d='M0 0l5 6 5-6z' fill='%23dcb964'/></svg>");
+    /* Caret tracks the active theme via `fill='currentColor'` — Vellum gold,
+       Editorial orange, dark/light variants of both, without per-skin overrides. */
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6'><path d='M0 0l5 6 5-6z' fill='currentColor'/></svg>");
     background-repeat: no-repeat;
     background-position: right 4px center;
     background-size: 7px 5px;
@@ -3373,7 +3400,9 @@
     color:#FF7A2D; font-family:'Syne',sans-serif; font-weight:800; font-size:12px;
     letter-spacing:.06em; text-transform:uppercase;
     padding:2px 14px 2px 4px;
-    background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6'><path d='M0 0l5 6 5-6z' fill='%23FF7A2D'/></svg>");
+    /* Caret tracks the chip's text color (`currentColor`) — orange in the
+       editorial popover today; future variants flow without per-skin overrides. */
+    background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6'><path d='M0 0l5 6 5-6z' fill='currentColor'/></svg>");
     background-repeat:no-repeat; background-position:right 0 center; background-size:7px 5px;
   }
   .ph-set-select::-ms-expand{ display:none; }
@@ -6416,13 +6445,14 @@ function _effectiveTheme(theme) {
   });
 
   // ── Skin picker — native <select> on both desktop and phone surfaces ──
-  // _SKINS is the source of truth; extend here when a new skin lands (#45) and
-  // both selects re-populate. Vellum has no data-skin attribute (default canvas).
+  // window._SKINS is defined in the anti-FOUC <script> at the top of <head> so
+  // both contexts share one source of truth (extending the registry is a single
+  // edit there). Flat skins set data-skin to their own id; overlays set
+  // data-skin to base AND data-variant to variant — kept in lockstep with the
+  // anti-FOUC resolution above.
   (function _initSkinPicker() {
-    const _SKINS = [
-      { id: 'vellum',    label: 'Vellum'    },
-      { id: 'editorial', label: 'Editorial' },
-    ];
+    const _SKINS = window._SKINS;
+    const root = document.documentElement;
 
     function _read() {
       let v = null; try { v = localStorage.getItem('dnd-skin'); } catch (_) {}
@@ -6430,9 +6460,13 @@ function _effectiveTheme(theme) {
     }
 
     function _apply(skin) {
-      if (skin === 'vellum') document.documentElement.removeAttribute('data-skin');
-      else document.documentElement.setAttribute('data-skin', skin);
-      try { localStorage.setItem('dnd-skin', skin); } catch (_) {}
+      const s = _SKINS.find(x => x.id === skin) || _SKINS[0];
+      const base = s.base || s.id;
+      if (base === 'vellum') root.removeAttribute('data-skin');
+      else root.setAttribute('data-skin', base);
+      if (s.variant) root.setAttribute('data-variant', s.variant);
+      else root.removeAttribute('data-variant');
+      try { localStorage.setItem('dnd-skin', s.id); } catch (_) {}
     }
 
     function _populate(select, current) {

--- a/skills/dnd/display/templates/index.html
+++ b/skills/dnd/display/templates/index.html
@@ -1355,6 +1355,29 @@
     border-color: rgba(220,185,100,0.6);
   }
 
+  /* Style picker — native <select> styled to match the chip aesthetic.
+     Native gives us free accessibility + the iOS picker wheel on phones.
+     Caret is drawn via background-image so it's consistent across browsers
+     (Firefox / Safari / Chrome all hide the default arrow differently). */
+  .theme-select {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    padding-right: 16px;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6'><path d='M0 0l5 6 5-6z' fill='%23dcb964'/></svg>");
+    background-repeat: no-repeat;
+    background-position: right 4px center;
+    background-size: 7px 5px;
+  }
+  .theme-select::-ms-expand { display: none; }
+  /* Option list — falls back to OS native styling on most browsers but
+     these rules apply where they take (Firefox, some Chromium versions). */
+  .theme-select option {
+    background: rgba(20, 14, 8, 0.95);
+    color: rgba(220, 185, 100, 0.92);
+    font-family: 'Cinzel', serif;
+  }
+
   /* ── TTS per-block bar ──
      Hidden until block is fully flushed (set by flushNewBlock).
      Dim at rest; bright on parent-block hover or focus-within. */
@@ -3341,6 +3364,20 @@
   .ph-set-opt:last-child{ border-bottom:0; }
   .ph-set-opt strong{ color:#FF7A2D; font-weight:800; font-size:12px; }
   .ph-set-opt:active{ background:rgba(255,255,255,.06); }
+  /* Phone-side <select> chip — matches the strong-text color of the cycle
+     buttons it replaces, surfaces the native iOS picker wheel on tap. */
+  .ph-set-row{ cursor:default; }
+  .ph-set-select{
+    -webkit-appearance:none; -moz-appearance:none; appearance:none;
+    background:transparent; border:0;
+    color:#FF7A2D; font-family:'Syne',sans-serif; font-weight:800; font-size:12px;
+    letter-spacing:.06em; text-transform:uppercase;
+    padding:2px 14px 2px 4px;
+    background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6'><path d='M0 0l5 6 5-6z' fill='%23FF7A2D'/></svg>");
+    background-repeat:no-repeat; background-position:right 0 center; background-size:7px 5px;
+  }
+  .ph-set-select::-ms-expand{ display:none; }
+  .ph-set-select option{ background:rgba(20,18,18,.98); color:#CFC7B5; font-family:'Syne',sans-serif; }
 
   /* ══ Phone character-select first screen (#char-select) — theme-aware via
         editorial vars with dark fallbacks (works in Vellum too) ══ */
@@ -3473,9 +3510,12 @@
     <span class="audio-label">Theme</span>
     <span id="theme-label" class="theme-label">Dark</span>
   </div>
-  <div class="audio-row" id="skin-row" title="Display style — Vellum (classic) / Editorial (new)">
+  <div class="audio-row" id="skin-row" title="Display style">
     <span class="audio-label">Style</span>
-    <span id="skin-label" class="theme-label">Vellum</span>
+    <select id="skin-select" class="theme-label theme-select" aria-label="Display style">
+      <option value="vellum">Vellum</option>
+      <option value="editorial">Editorial</option>
+    </select>
   </div>
   <div class="audio-row" id="onscreen-dice-row" title="Open the dice roller on this screen when the DM calls for a roll (for games without phones)">
     <span class="audio-label">Roll on screen</span>
@@ -3536,7 +3576,7 @@
   <button id="ph-set-toggle" type="button" title="Display settings" aria-label="Display settings">⚙</button>
   <div id="ph-set-menu" role="menu">
     <button class="ph-set-opt" id="ph-theme-opt" type="button"><span>Theme</span><strong id="ph-theme-val">Dark</strong></button>
-    <button class="ph-set-opt" id="ph-skin-opt" type="button"><span>Style</span><strong id="ph-skin-val">Vellum</strong></button>
+    <label class="ph-set-opt ph-set-row" id="ph-skin-opt"><span>Style</span><select id="ph-skin-select" class="ph-set-select" aria-label="Display style"><option value="vellum">Vellum</option><option value="editorial">Editorial</option></select></label>
     <button class="ph-set-opt" id="ph-roll-opt" type="button" hidden><span>Rolls</span><strong id="ph-roll-val">Players</strong></button>
   </div>
 </div>
@@ -6375,25 +6415,54 @@ function _effectiveTheme(theme) {
     refresh();
   });
 
-  // ── Skin picker (Vellum ↔ Editorial) — parallel axis to theme ──
+  // ── Skin picker — native <select> on both desktop and phone surfaces ──
+  // _SKINS is the source of truth; extend here when a new skin lands (#45) and
+  // both selects re-populate. Vellum has no data-skin attribute (default canvas).
   (function _initSkinPicker() {
-    const srow = document.getElementById('skin-row');
-    const slabel = document.getElementById('skin-label');
-    if (!srow || !slabel) return;
-    let skin = 'vellum';
-    try { if (localStorage.getItem('dnd-skin') === 'editorial') skin = 'editorial'; } catch (_) {}
-    function applySkin() {
-      if (skin === 'editorial') document.documentElement.setAttribute('data-skin', 'editorial');
-      else document.documentElement.removeAttribute('data-skin');
-      slabel.textContent = skin === 'editorial' ? 'Editorial' : 'Vellum';
-      slabel.classList.toggle('on', skin === 'editorial');
+    const _SKINS = [
+      { id: 'vellum',    label: 'Vellum'    },
+      { id: 'editorial', label: 'Editorial' },
+    ];
+
+    function _read() {
+      let v = null; try { v = localStorage.getItem('dnd-skin'); } catch (_) {}
+      return _SKINS.some(s => s.id === v) ? v : 'vellum';
     }
-    applySkin();
-    srow.addEventListener('click', () => {
-      skin = (skin === 'editorial') ? 'vellum' : 'editorial';
+
+    function _apply(skin) {
+      if (skin === 'vellum') document.documentElement.removeAttribute('data-skin');
+      else document.documentElement.setAttribute('data-skin', skin);
       try { localStorage.setItem('dnd-skin', skin); } catch (_) {}
-      applySkin();
-    });
+    }
+
+    function _populate(select, current) {
+      if (!select) return;
+      // Idempotent — overwrite contents from _SKINS so any future skin addition
+      // shows up in both selects without DOM surgery elsewhere.
+      select.innerHTML = _SKINS.map(s =>
+        `<option value="${s.id}"${s.id === current ? ' selected' : ''}>${s.label}</option>`
+      ).join('');
+      select.value = current;
+    }
+
+    const desktop = document.getElementById('skin-select');
+    const phone   = document.getElementById('ph-skin-select');
+    let skin = _read();
+    _populate(desktop, skin);
+    _populate(phone, skin);
+    _apply(skin);
+
+    function _onChange(e) {
+      skin = e.target.value;
+      _apply(skin);
+      // Keep both surfaces in sync if the user has the desktop dev-tools open
+      // while changing on phone, or vice versa.
+      if (desktop && desktop !== e.target) desktop.value = skin;
+      if (phone   && phone   !== e.target) phone.value   = skin;
+    }
+
+    if (desktop) desktop.addEventListener('change', _onChange);
+    if (phone)   phone.addEventListener('change', _onChange);
   })();
 
   // Track system-pref changes so auto mode stays accurate without reload
@@ -7274,22 +7343,22 @@ function _onscreenDiceOn() { try { return localStorage.getItem('dnd-onscreen-dic
     if (!wrap || !document.body.classList.contains('input-only')) return;
     const tog    = document.getElementById('ph-set-toggle');
     const menu   = document.getElementById('ph-set-menu');
+    // Theme stays click-to-cycle (3 values: dark/light/auto — cycle's fine at 3).
+    // Style is its own <select id="ph-skin-select"> wired in _initSkinPicker.
     const tVal   = document.getElementById('ph-theme-val');
-    const sVal   = document.getElementById('ph-skin-val');
     const tRow   = document.getElementById('theme-row');
-    const sRow   = document.getElementById('skin-row');
     const tLabel = document.getElementById('theme-label');
-    const sLabel = document.getElementById('skin-label');
-    function refresh() {
+    function refreshTheme() {
       if (tLabel && tVal) tVal.textContent = tLabel.textContent;
-      if (sLabel && sVal) sVal.textContent = sLabel.textContent;
     }
-    refresh();
+    refreshTheme();
     if (tog) tog.addEventListener('click', e => { e.stopPropagation(); menu.classList.toggle('open'); });
     const tOpt = document.getElementById('ph-theme-opt');
+    if (tOpt) tOpt.addEventListener('click', e => { e.stopPropagation(); if (tRow) tRow.click(); refreshTheme(); });
+    // Phone Style select lives inside the menu — stop click bubbling so opening
+    // the native picker doesn't close the menu via the document-click listener.
     const sOpt = document.getElementById('ph-skin-opt');
-    if (tOpt) tOpt.addEventListener('click', e => { e.stopPropagation(); if (tRow) tRow.click(); refresh(); });
-    if (sOpt) sOpt.addEventListener('click', e => { e.stopPropagation(); if (sRow) sRow.click(); refresh(); });
+    if (sOpt) sOpt.addEventListener('click', e => e.stopPropagation());
 
     // Per-player roll override — only meaningful when this phone is bound to a PC.
     const boundChar = new URLSearchParams(location.search).get('char')


### PR DESCRIPTION
Small infrastructure prep ahead of the theme-variants work in #45 / #46. The Style row click-to-cycle becomes a native \`<select>\` chip that scales gracefully to the curated 6-skin proposal.

## What changes

- **#skin-row**: \`<span id=\"skin-label\">\` → \`<select id=\"skin-select\">\` styled as a chip to match the existing TYPE SPEED / AUTO NARRATE / THEME aesthetic.
- **Phone popover** (\`#ph-skin-opt\`): button-with-cycle → label-wrapped \`<select id=\"ph-skin-select\">\`. iOS shows the native picker wheel on tap.
- **\`_initSkinPicker\`** rewrites the click closure to listen for \`change\` events on both selects + sync them. Source of truth is a single \`_SKINS\` array; adding a new skin in a future PR is one line.
- **Phone settings popover** drops the desktop-cycle delegation. Theme stays click-to-cycle (only 3 values — fine at that count).
- Click bubbling stops on the phone-side label so opening the native picker doesn't close the settings menu.

## Why now

- Click-cycle works at 2 skins. Cycling through 5–6 (per #45's curated set) would feel cramped, and you can't see options before tapping.
- Lands separately so future skin PRs (Haunted first, per #45) stay pure design reviews instead of also handling cycle-vs-dropdown UX.

## Verification

- Editorial: orange caret + chip styling matches the existing chip language.
- Vellum: gold caret + chip styling matches the classic aesthetic.
- 89/89 tests passing on this branch.

## What's NOT in this PR

- No new skin values — \`_SKINS\` is still \`[vellum, editorial]\`. Each new variant lands as its own PR.
- No picker grid / modal UI for high-N skin counts — native \`<select>\` scales fine to the curated 6.