### PR TITLE
fix(skill): remove incorrect 2024 monster-crit row from ruleset table

### DIFF
--- a/skills/dnd/SKILL.md
+++ b/skills/dnd/SKILL.md
@@ -37,7 +37,6 @@ The differences that affect Claude's narration and resolution at the table:
 | Exhaustion | 6 levels with discrete effects | Cumulative -2 to all d20 rolls per level (max 10) |
 | Inspiration label | "Inspiration" | "Heroic Inspiration" (same mechanic) |
 | Crit damage (PCs) | Nat 20 → double dice | Nat 20 → double dice (unchanged) |
-| Crit damage (NPCs/monsters) | Same as PCs | Monsters cannot crit on PCs |
 | Cantrip damage scaling tiers | Levels 5/11/17 | Same |
 | Extra Attack progression | Fighter at 5/11/20 | Same |
 


### PR DESCRIPTION
## Summary
- Removes the row claiming monsters cannot crit on PCs under the 2024 ruleset
- The restriction was a One D&D playtest change that was reversed before the final 2024 PHB shipped; SRD 5.2 keeps monster crits (Paralyzed condition and Adamantine armor entries both presuppose them)
- 2014 and 2024 land on the same rule here, so the row is dropped rather than corrected — the table exists to highlight ruleset differences

Closes #52.

## Test plan
- [ ] Visual check of the 2014↔2024 differences table in `skills/dnd/SKILL.md` — surrounding rows (ability scores, subclass L3, weapon masteries, exhaustion, etc.) still present and correct