### PR TITLE
chore(tooling): show full patch version in the skill picker prefix

### DIFF
--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -7,7 +7,7 @@ drift-prone. This updates them all (and optionally commits + tags):
   1. VERSION                          — source of truth
   2. .claude-plugin/plugin.json       — top-level "version"
   3. .claude-plugin/marketplace.json  — the `dm` plugin entry's "version"
-  4. skills/dnd/SKILL.md              — the "vMAJOR.MINOR ·" slash-picker prefix
+  4. skills/dnd/SKILL.md              — the "vMAJOR.MINOR.PATCH ·" slash-picker prefix
   5. CHANGELOG.md                     — promote [Unreleased] → [X.Y.Z] — <date>
 
 Usage:
@@ -87,16 +87,16 @@ def bump_marketplace_json(root, old, new, dry):
 
 
 def bump_skill_description(root, old, new, dry):
-    # The picker prefix is "vMAJOR.MINOR ·" — patch releases keep the same prefix.
+    # The picker prefix is "vMAJOR.MINOR.PATCH ·" — the full release shows in the
+    # slash-command picker so the exact running version is visible at a glance.
     p = root / "skills" / "dnd" / "SKILL.md"
-    maj, minr, _ = new.split(".")
     out, n = re.subn(r'(description:\s*"?)v\d+\.\d+(?:\.\d+)?(\s*·)',
-                     rf'\g<1>v{maj}.{minr}\g<2>', _read(p))
+                     rf'\g<1>v{new}\g<2>', _read(p))
     if n != 1:
-        raise BumpError(f"SKILL.md: expected 1 'vX.Y ·' prefix, found {n}")
+        raise BumpError(f"SKILL.md: expected 1 'vX.Y[.Z] ·' prefix, found {n}")
     if not dry:
         p.write_text(out)
-    return f"skills/dnd/SKILL.md (picker prefix → v{maj}.{minr})"
+    return f"skills/dnd/SKILL.md (picker prefix → v{new})"
 
 
 def bump_changelog(root, old, new, date, title, dry):

--- a/skills/dnd/SKILL.md
+++ b/skills/dnd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dnd
-description: "v2.1 · Dungeon Master assistant for running persistent D&D 5e campaigns. Handles campaign creation/loading, character management, combat tracking, NPC generation, dice rolling, and session state — all persisted across sessions. Invoke with /dm:dnd followed by a subcommand, or just speak naturally once a campaign is loaded."
+description: "v2.1.4 · Dungeon Master assistant for running persistent D&D 5e campaigns. Handles campaign creation/loading, character management, combat tracking, NPC generation, dice rolling, and session state — all persisted across sessions. Invoke with /dm:dnd followed by a subcommand, or just speak naturally once a campaign is loaded."
 tools: Read, Write, Edit, Glob, Bash, AskUserQuestion
 ---
 


### PR DESCRIPTION
## What
The slash-command picker shows the skill description's version prefix (the `(dm) v2.1 · …` you see when typing `/dnd` / `/dm:dnd`). It currently shows **minor-only** (`v2.1`), so the exact patch isn't visible — you can't tell `2.1.0` from `2.1.4` at a glance.

This switches it to the **full `vMAJOR.MINOR.PATCH`** (`v2.1.4`):
- `bump_version.py` now writes the full 3-place prefix on every release (was deliberately truncated to minor).
- `SKILL.md` description bumped to `v2.1.4` to match the current release.

## Why
The minor-only prefix was an intentional choice (constant across patches). But in practice it's made "which build am I actually running?" genuinely hard to answer — including a recent case where a released `v2.1.4` was unreachable via `/plugin update` and there was no easy in-app way to see the installed patch. Surfacing the exact version right in the picker makes that obvious, which feels worth the small extra churn of the prefix changing each patch.

Flagging the tradeoff since the minor-only behavior was deliberate, @Bobby-Gray — easy to revert the `bump_version.py` line if you'd rather keep it stable across patches.

## Verification
`bump_version.py 2.1.5 --dry-run` → `skills/dnd/SKILL.md (picker prefix → v2.1.5)` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
