### PR TITLE
chore: sync v2.2.1 across marketplace.json + SKILL.md picker prefix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "dm",
       "source": "./",
       "description": "Dungeon Master assistant for persistent D&D 5e campaigns — campaign/character management, combat, NPCs, dice, an optional live display companion, and full session state across sessions.",
-      "version": "2.1.4",
+      "version": "2.2.1",
       "license": "AGPL-3.0-or-later",
       "keywords": ["dnd", "dungeons-and-dragons", "ttrpg", "5e", "dungeon-master", "game"]
     }

--- a/skills/dnd/SKILL.md
+++ b/skills/dnd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dnd
-description: "v2.1.4 · Dungeon Master assistant for running persistent D&D 5e campaigns. Handles campaign creation/loading, character management, combat tracking, NPC generation, dice rolling, and session state — all persisted across sessions. Invoke with /dm:dnd followed by a subcommand, or just speak naturally once a campaign is loaded."
+description: "v2.2.1 · Dungeon Master assistant for running persistent D&D 5e campaigns. Handles campaign creation/loading, character management, combat tracking, NPC generation, dice rolling, and session state — all persisted across sessions. Invoke with /dm:dnd followed by a subcommand, or just speak naturally once a campaign is loaded."
 tools: Read, Write, Edit, Glob, Bash, AskUserQuestion
 ---
 


### PR DESCRIPTION
The v2.2.0/v2.2.1 releases bumped VERSION and plugin.json by hand and missed two of the five canonical version locations `scripts/bump_version.py` keeps in lockstep: the `marketplace.json` `dm` plugin entry and the SKILL.md `vX.Y.Z ·` slash-picker prefix (both stale at 2.1.4). This brings them to 2.2.1.

Marketplace `metadata.version` (1.0.0) is independent and intentionally untouched. Verified: `bump_version.py 2.2.2 --dry-run` now matches cleanly across all five files. Going forward, releases should use `bump_version.py` to avoid this drift.